### PR TITLE
Add namespace to support multiple nodes

### DIFF
--- a/launch/socket_can_bridge.launch.xml
+++ b/launch/socket_can_bridge.launch.xml
@@ -1,18 +1,15 @@
 <launch>
 
-  <arg name="namespace" default="" />
   <arg name="interface" default="can0" />
   <arg name="receiver_interval_sec" default="0.01" />
   <arg name="sender_timeout_sec" default="0.01" />
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py">
-    <arg name="namespace" value="$(var namespace)" />
     <arg name="interface" value="$(var interface)" />
     <arg name="interval_sec" value="$(var receiver_interval_sec)" />
   </include>
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_sender.launch.py">
-    <arg name="namespace" value="$(var namespace)" />
     <arg name="interface" value="$(var interface)" />
     <arg name="timeout_sec" value="$(var sender_timeout_sec)" />
   </include>

--- a/launch/socket_can_bridge.launch.xml
+++ b/launch/socket_can_bridge.launch.xml
@@ -1,15 +1,18 @@
 <launch>
 
+  <arg name="namespace" default="" />
   <arg name="interface" default="can0" />
   <arg name="receiver_interval_sec" default="0.01" />
   <arg name="sender_timeout_sec" default="0.01" />
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py">
+    <arg name="namespace" value="$(var namespace)" />
     <arg name="interface" value="$(var interface)" />
     <arg name="interval_sec" value="$(var receiver_interval_sec)" />
   </include>
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_sender.launch.py">
+    <arg name="namespace" value="$(var namespace)" />
     <arg name="interface" value="$(var interface)" />
     <arg name="timeout_sec" value="$(var sender_timeout_sec)" />
   </include>

--- a/launch/socket_can_receiver.launch.py
+++ b/launch/socket_can_receiver.launch.py
@@ -19,7 +19,7 @@ from launch import LaunchDescription
 from launch.events import matches_action
 from launch.actions import DeclareLaunchArgument, EmitEvent
 from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, TextSubstitution
 
 from launch_ros.actions import LifecycleNode
 from launch_ros.events.lifecycle import ChangeState
@@ -31,7 +31,7 @@ def generate_launch_description():
     socket_can_receiver_node = LifecycleNode(package='ros2_socketcan',
                                              executable='socket_can_receiver_node_exe',
                                              name='socket_can_receiver',
-                                             namespace=LaunchConfiguration('namespace'),
+                                             namespace=TextSubstitution(text=""),
                                              parameters=[{
                                                  'interface': LaunchConfiguration('interface'),
                                                  'interval_sec':
@@ -56,7 +56,6 @@ def generate_launch_description():
     )
 
     return LaunchDescription([
-        DeclareLaunchArgument('namespace', default_value=''),
         DeclareLaunchArgument('interface', default_value='can0'),
         DeclareLaunchArgument('interval_sec', default_value='0.01'),
         DeclareLaunchArgument('auto_configure', default_value='true'),

--- a/launch/socket_can_receiver.launch.py
+++ b/launch/socket_can_receiver.launch.py
@@ -16,14 +16,12 @@
 
 
 from launch import LaunchDescription
-from launch.events import matches_action
 from launch.actions import DeclareLaunchArgument, EmitEvent
 from launch.conditions import IfCondition
+from launch.events import matches_action
 from launch.substitutions import LaunchConfiguration, TextSubstitution
-
 from launch_ros.actions import LifecycleNode
 from launch_ros.events.lifecycle import ChangeState
-
 import lifecycle_msgs.msg
 
 
@@ -31,7 +29,7 @@ def generate_launch_description():
     socket_can_receiver_node = LifecycleNode(package='ros2_socketcan',
                                              executable='socket_can_receiver_node_exe',
                                              name='socket_can_receiver',
-                                             namespace=TextSubstitution(text=""),
+                                             namespace=TextSubstitution(text=''),
                                              parameters=[{
                                                  'interface': LaunchConfiguration('interface'),
                                                  'interval_sec':

--- a/launch/socket_can_receiver.launch.py
+++ b/launch/socket_can_receiver.launch.py
@@ -16,12 +16,13 @@
 
 
 from launch import LaunchDescription
+from launch.events import matches_action
 from launch.actions import DeclareLaunchArgument, EmitEvent
 from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import LifecycleNode
-from launch_ros.events.lifecycle import ChangeState, matches_node_name
+from launch_ros.events.lifecycle import ChangeState
 
 import lifecycle_msgs.msg
 
@@ -30,6 +31,7 @@ def generate_launch_description():
     socket_can_receiver_node = LifecycleNode(package='ros2_socketcan',
                                              executable='socket_can_receiver_node_exe',
                                              name='socket_can_receiver',
+                                             namespace=LaunchConfiguration('namespace'),
                                              parameters=[{
                                                  'interface': LaunchConfiguration('interface'),
                                                  'interval_sec':
@@ -39,7 +41,7 @@ def generate_launch_description():
 
     socket_can_receiver_configure_trans_event = EmitEvent(
         event=ChangeState(
-            lifecycle_node_matcher=matches_node_name('/socket_can_receiver'),
+            lifecycle_node_matcher=matches_action(socket_can_receiver_node),
             transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
         ),
         condition=IfCondition(LaunchConfiguration('auto_configure')),
@@ -47,13 +49,14 @@ def generate_launch_description():
 
     socket_can_receiver_activate_trans_event = EmitEvent(
         event=ChangeState(
-            lifecycle_node_matcher=matches_node_name('/socket_can_receiver'),
+            lifecycle_node_matcher=matches_action(socket_can_receiver_node),
             transition_id=lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE,
         ),
         condition=IfCondition(LaunchConfiguration('auto_activate')),
     )
 
     return LaunchDescription([
+        DeclareLaunchArgument('namespace', default_value=''),
         DeclareLaunchArgument('interface', default_value='can0'),
         DeclareLaunchArgument('interval_sec', default_value='0.01'),
         DeclareLaunchArgument('auto_configure', default_value='true'),

--- a/launch/socket_can_sender.launch.py
+++ b/launch/socket_can_sender.launch.py
@@ -16,14 +16,12 @@
 
 
 from launch import LaunchDescription
-from launch.events import matches_action
 from launch.actions import DeclareLaunchArgument, EmitEvent
 from launch.conditions import IfCondition
+from launch.events import matches_action
 from launch.substitutions import LaunchConfiguration, TextSubstitution
-
 from launch_ros.actions import LifecycleNode
 from launch_ros.events.lifecycle import ChangeState
-
 import lifecycle_msgs.msg
 
 
@@ -31,7 +29,7 @@ def generate_launch_description():
     socket_can_sender_node = LifecycleNode(package='ros2_socketcan',
                                            executable='socket_can_sender_node_exe',
                                            name='socket_can_sender',
-                                           namespace=TextSubstitution(text=""),
+                                           namespace=TextSubstitution(text=''),
                                            parameters=[{
                                                'interface': LaunchConfiguration('interface'),
                                                'timeout_sec':

--- a/launch/socket_can_sender.launch.py
+++ b/launch/socket_can_sender.launch.py
@@ -19,7 +19,7 @@ from launch import LaunchDescription
 from launch.events import matches_action
 from launch.actions import DeclareLaunchArgument, EmitEvent
 from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, TextSubstitution
 
 from launch_ros.actions import LifecycleNode
 from launch_ros.events.lifecycle import ChangeState
@@ -31,7 +31,7 @@ def generate_launch_description():
     socket_can_sender_node = LifecycleNode(package='ros2_socketcan',
                                            executable='socket_can_sender_node_exe',
                                            name='socket_can_sender',
-                                           namespace=LaunchConfiguration('namespace'),
+                                           namespace=TextSubstitution(text=""),
                                            parameters=[{
                                                'interface': LaunchConfiguration('interface'),
                                                'timeout_sec':
@@ -56,7 +56,6 @@ def generate_launch_description():
     )
 
     return LaunchDescription([
-        DeclareLaunchArgument('namespace', default_value=''),
         DeclareLaunchArgument('interface', default_value='can0'),
         DeclareLaunchArgument('timeout_sec', default_value='0.01'),
         DeclareLaunchArgument('auto_configure', default_value='true'),


### PR DESCRIPTION
## Overview

If we have two CAN buses, we'd like to launch socket_can_bridge multiple times.
However, the current code doesn't support such a use case.

Ideally, it's better if we can use `<push-ros-namespace>` for `launch.py`, but it seems not supported, right?
So I've added `namespace` arg to support this use case.

Note: `matches_node_name` was replaced by `matches_action` for easiler code.

## How to test

### Prepare

```sh
sudo modprobe vcan

# CAN Bus 1
sudo ip link add dev vcan0 type vcan
sudo ip link set vcan0 up

# CAN Bus 2
sudo ip link add dev vcan1 type vcan
sudo ip link set vcan1 up
```

### Test

```sh
$ ros2 launch ros2_socketcan socket_can_bridge.launch.xml namespace:=bus1 interface:=vcan0
$ ros2 launch ros2_socketcan socket_can_bridge.launch.xml namespace:=bus2 interface:=vcan1

$ ros2 node list
/bus1/socket_can_receiver
/bus1/socket_can_sender
/bus2/socket_can_receiver
/bus2/socket_can_sender
/launch_ros_2251954
/launch_ros_2253074

$ ros2 topic list
/bus1/can_rx
/bus1/can_tx
/bus1/socket_can_receiver/transition_event
/bus1/socket_can_sender/transition_event
/bus2/can_rx
/bus2/can_tx
/bus2/socket_can_receiver/transition_event
/bus2/socket_can_sender/transition_event
/parameter_events
/rosout

$ ros2 lifecycle get /bus1/socket_can_sender
active [3]

$ ros2 lifecycle get /bus2/socket_can_sender
active [3]

# Run `cansend vcan0 123#45` background
$ ros2 topic echo /bus1/can_tx
header:
  stamp:
    sec: 1615469217
    nanosec: 346618145
  frame_id: can
id: 291
is_rtr: false
is_extended: false
is_error: false
dlc: 1
data:
- 69
- 0
- 0
- 0
- 0
- 0
- 0
- 0
---
```