### PR TITLE
Make receiver thread

### DIFF
--- a/include/ros2_socketcan/socket_can_receiver_node.hpp
+++ b/include/ros2_socketcan/socket_can_receiver_node.hpp
@@ -27,6 +27,7 @@
 #include <can_msgs/msg/frame.hpp>
 
 #include <memory>
+#include <thread>
 #include <string>
 
 namespace lc = rclcpp_lifecycle;
@@ -72,7 +73,7 @@ private:
   std::string interface_;
   std::shared_ptr<lc::LifecyclePublisher<can_msgs::msg::Frame>> frames_pub_;
   std::unique_ptr<SocketCanReceiver> receiver_;
-  rclcpp::TimerBase::SharedPtr timer_;
+  std::unique_ptr<std::thread> receiver_thread_;
   std::chrono::nanoseconds interval_ns_;
 };
 }  // namespace socketcan

--- a/include/ros2_socketcan/socket_can_receiver_node.hpp
+++ b/include/ros2_socketcan/socket_can_receiver_node.hpp
@@ -25,6 +25,7 @@
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <rosidl_runtime_cpp/message_initialization.hpp>
 #include <can_msgs/msg/frame.hpp>
+#include <lifecycle_msgs/msg/state.hpp>
 
 #include <memory>
 #include <thread>

--- a/src/socket_can_receiver.cpp
+++ b/src/socket_can_receiver.cpp
@@ -51,11 +51,11 @@ void SocketCanReceiver::wait(const std::chrono::nanoseconds timeout) const
     auto read_set = single_set(m_file_descriptor);
     // Wait
     if (0 == select(m_file_descriptor + 1, &read_set, NULL, NULL, &c_timeout)) {
-      throw SocketCanTimeout{"CAN Send Timeout"};
+      throw SocketCanTimeout{"CAN Receive Timeout"};
     }
     //lint --e{9130, 1924, 9123, 9125, 1924, 9126} NOLINT
     if (!FD_ISSET(m_file_descriptor, &read_set)) {
-      throw SocketCanTimeout{"CAN Send timeout"};
+      throw SocketCanTimeout{"CAN Receive timeout"};
     }
   }
 }

--- a/src/socket_can_receiver_node.cpp
+++ b/src/socket_can_receiver_node.cpp
@@ -23,6 +23,7 @@
 
 namespace lc = rclcpp_lifecycle;
 using LNI = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface;
+using lifecycle_msgs::msg::State;
 using namespace std::chrono_literals;
 
 namespace drivers
@@ -103,6 +104,10 @@ void SocketCanReceiverNode::receive()
   frame_msg.header.frame_id = "can";
 
   while (rclcpp::ok()) {
+    if (this->get_current_state().id() != State::PRIMARY_STATE_ACTIVE) {
+      continue;
+    }
+
     try {
       receive_id = receiver_->receive(frame_msg.data.data(), interval_ns_);
     } catch (const std::exception & ex) {

--- a/src/socket_can_receiver_node.cpp
+++ b/src/socket_can_receiver_node.cpp
@@ -105,6 +105,7 @@ void SocketCanReceiverNode::receive()
 
   while (rclcpp::ok()) {
     if (this->get_current_state().id() != State::PRIMARY_STATE_ACTIVE) {
+      std::this_thread::sleep_for(500ns);
       continue;
     }
 

--- a/src/socket_can_receiver_node.cpp
+++ b/src/socket_can_receiver_node.cpp
@@ -57,11 +57,7 @@ LNI::CallbackReturn SocketCanReceiverNode::on_configure(const lc::State & state)
   RCLCPP_DEBUG(this->get_logger(), "Receiver successfully configured.");
   frames_pub_ = this->create_publisher<can_msgs::msg::Frame>("from_can_bus", 500);
 
-  auto on_timer = std::bind(&SocketCanReceiverNode::receive, this);
-  timer_ = std::make_shared<rclcpp::GenericTimer<decltype(on_timer)>>(
-    this->get_clock(), interval_ns_, std::move(on_timer),
-    this->get_node_base_interface()->get_context());
-  this->get_node_timers_interface()->add_timer(timer_, nullptr);
+  receiver_thread_ = std::make_unique<std::thread>(&SocketCanReceiverNode::receive, this);
 
   return LNI::CallbackReturn::SUCCESS;
 }
@@ -86,7 +82,9 @@ LNI::CallbackReturn SocketCanReceiverNode::on_cleanup(const lc::State & state)
 {
   (void)state;
   frames_pub_.reset();
-  timer_.reset();
+  if (receiver_thread_->joinable()) {
+    receiver_thread_->join();
+  }
   RCLCPP_DEBUG(this->get_logger(), "Receiver cleaned up.");
   return LNI::CallbackReturn::SUCCESS;
 }
@@ -103,22 +101,25 @@ void SocketCanReceiverNode::receive()
   CanId receive_id{};
   can_msgs::msg::Frame frame_msg(rosidl_runtime_cpp::MessageInitialization::ZERO);
   frame_msg.header.frame_id = "can";
-  try {
-    receive_id = receiver_->receive(frame_msg.data.data(), interval_ns_);
-  } catch (const std::exception & ex) {
-    RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), 1000,
-      "Error receiving CAN message: %s - %s",
-      interface_.c_str(), ex.what());
-    return;
+
+  while (rclcpp::ok()) {
+    try {
+      receive_id = receiver_->receive(frame_msg.data.data(), interval_ns_);
+    } catch (const std::exception & ex) {
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), 1000,
+        "Error receiving CAN message: %s - %s",
+        interface_.c_str(), ex.what());
+      continue;
+    }
+    frame_msg.header.stamp = this->now();
+    frame_msg.id = receive_id.identifier();
+    frame_msg.is_rtr = (receive_id.frame_type() == FrameType::REMOTE);
+    frame_msg.is_extended = receive_id.is_extended();
+    frame_msg.is_error = (receive_id.frame_type() == FrameType::ERROR);
+    frame_msg.dlc = receive_id.length();
+    frames_pub_->publish(std::move(frame_msg));
   }
-  frame_msg.header.stamp = this->now();
-  frame_msg.id = receive_id.identifier();
-  frame_msg.is_rtr = (receive_id.frame_type() == FrameType::REMOTE);
-  frame_msg.is_extended = receive_id.is_extended();
-  frame_msg.is_error = (receive_id.frame_type() == FrameType::ERROR);
-  frame_msg.dlc = receive_id.length();
-  frames_pub_->publish(std::move(frame_msg));
 }
 
 }  // namespace socketcan

--- a/src/socket_can_receiver_node.cpp
+++ b/src/socket_can_receiver_node.cpp
@@ -105,7 +105,7 @@ void SocketCanReceiverNode::receive()
 
   while (rclcpp::ok()) {
     if (this->get_current_state().id() != State::PRIMARY_STATE_ACTIVE) {
-      std::this_thread::sleep_for(500ns);
+      std::this_thread::sleep_for(100ms);
       continue;
     }
 


### PR DESCRIPTION
We found that the current receiver can't publish topics at the expected rate.
Suppose that there are 10 can frames they have different ids and they are published at 10Hz, then the rate of can topics will be 100Hz(10Hz x 10).
Then, reading can msgs at 10Hz(0.1) doesn't work correctly because it reads only one message in each timer callback.

Please see the following result.

```sh
# Launch nodes
$ ros2 launch ros2_socketcan socket_can_bridge.launch.xml interface:=vcan0 receiver_interval_sec:=0.1

# Create dummy can data(because `cansend` and `sleep` didn't work well...)
$ python3 make_candump.py

# Send can frames in 100Hz
$ canplayer -I candump.log

# Check hz
$ ros2 topic hz /can_tx
1616061813.765586 [19]       ros2: using network interface enp3s0 (udp/10.0.52.60) selected arbitrarily from: enp3s0, docker0
average rate: 9.995
	min: 0.100s max: 0.101s std dev: 0.00015s window: 11
average rate: 9.998
	min: 0.099s max: 0.101s std dev: 0.00022s window: 22
average rate: 9.998
	min: 0.099s max: 0.101s std dev: 0.00019s window: 33
average rate: 9.999
	min: 0.099s max: 0.101s std dev: 0.00017s window: 43
average rate: 9.999
	min: 0.099s max: 0.101s std dev: 0.00015s window: 54
average rate: 10.000
```

So I replace the timer with a while-loop.
With this PR, the receiver can publish topics at 100Hz with `interval = 0.1sec`.

```sh
# Launch nodes
$ ros2 launch ros2_socketcan socket_can_bridge.launch.xml interface:=vcan0 receiver_interval_sec:=0.1

# Send can frames in 100Hz
$ canplayer -I candump.log

# Check hz
$ ros2 topic hz /can_tx
1616062124.639030 [19]       ros2: using network interface enp3s0 (udp/10.0.52.60) selected arbitrarily from: enp3s0, docker0
average rate: 100.001
	min: 0.009s max: 0.011s std dev: 0.00026s window: 101
average rate: 100.016
	min: 0.009s max: 0.011s std dev: 0.00023s window: 202
average rate: 99.994
	min: 0.008s max: 0.012s std dev: 0.00027s window: 302
average rate: 100.007
	min: 0.008s max: 0.012s std dev: 0.00024s window: 403
average rate: 100.001
	min: 0.008s max: 0.012s std dev: 0.00024s window: 503
```

This is a simple helper script for making a can log.

```py
// make_candump.py
from pathlib import Path

# Parameters
log = Path("candump.log")
dt = 0.01
duration = 100
interface = "vcan0"
data = "123#45"

t = 0.0
with open(log, "w") as f:
    while t < duration:
        line = f"({t:.6f}) {interface} {data}\n"
        f.write(line)
        t += dt
```