### PR TITLE
Fix condition of RegisterEventHandler

### DIFF
--- a/launch/socket_can_receiver.launch.py
+++ b/launch/socket_can_receiver.launch.py
@@ -50,10 +50,10 @@ def generate_launch_description():
                         lifecycle_node_matcher=matches_action(socket_can_receiver_node),
                         transition_id=Transition.TRANSITION_CONFIGURE,
                     ),
-                    condition=IfCondition(LaunchConfiguration('auto_configure')),
                 ),
             ],
-        )
+        ),
+        condition=IfCondition(LaunchConfiguration('auto_configure')),
     )
 
     socket_can_receiver_activate_event_handler = RegisterEventHandler(
@@ -67,10 +67,10 @@ def generate_launch_description():
                         lifecycle_node_matcher=matches_action(socket_can_receiver_node),
                         transition_id=Transition.TRANSITION_ACTIVATE,
                     ),
-                    condition=IfCondition(LaunchConfiguration('auto_activate')),
                 ),
             ],
         ),
+        condition=IfCondition(LaunchConfiguration('auto_activate')),
     )
 
     return LaunchDescription([

--- a/launch/socket_can_sender.launch.py
+++ b/launch/socket_can_sender.launch.py
@@ -50,10 +50,10 @@ def generate_launch_description():
                         lifecycle_node_matcher=matches_action(socket_can_sender_node),
                         transition_id=Transition.TRANSITION_CONFIGURE,
                     ),
-                    condition=IfCondition(LaunchConfiguration('auto_configure')),
                 ),
             ],
-        )
+        ),
+        condition=IfCondition(LaunchConfiguration('auto_configure')),
     )
 
     socket_can_sender_activate_event_handler = RegisterEventHandler(
@@ -67,10 +67,10 @@ def generate_launch_description():
                         lifecycle_node_matcher=matches_action(socket_can_sender_node),
                         transition_id=Transition.TRANSITION_ACTIVATE,
                     ),
-                    condition=IfCondition(LaunchConfiguration('auto_activate')),
                 ),
             ],
         ),
+        condition=IfCondition(LaunchConfiguration('auto_activate')),
     )
 
     return LaunchDescription([


### PR DESCRIPTION
Resolves #8 

Move `condition` from `EmitEvent` to `RegisterEventHandler` to make it working with `group` tag.

I feel this makes the code more natural, `switching whether to register evenr_handlers` is better than `always registering event_handlers that emit depending on some conditions`.