### PR TITLE
WIP: Add Bus Time Option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(ros2_socketcan)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/include/ros2_socketcan/socket_can_common.hpp
+++ b/include/ros2_socketcan/socket_can_common.hpp
@@ -23,6 +23,15 @@
 #include <chrono>
 #include <string>
 
+/**
+ * Convert timeval to microseconds from epoch
+ * @param tv
+ * @return epoch time
+ */
+inline uint64_t tv2TimeStamp(struct timeval tv) {
+    return uint64_t(tv.tv_sec)*1e6 + tv.tv_usec;
+}
+
 namespace drivers
 {
 namespace socketcan

--- a/include/ros2_socketcan/socket_can_receiver_node.hpp
+++ b/include/ros2_socketcan/socket_can_receiver_node.hpp
@@ -76,6 +76,7 @@ private:
   std::unique_ptr<SocketCanReceiver> receiver_;
   std::unique_ptr<std::thread> receiver_thread_;
   std::chrono::nanoseconds interval_ns_;
+  bool use_bus_time_;
 };
 }  // namespace socketcan
 }  // namespace drivers

--- a/launch/socket_can_receiver.launch.py
+++ b/launch/socket_can_receiver.launch.py
@@ -38,6 +38,7 @@ def generate_launch_description():
             'interface': LaunchConfiguration('interface'),
             'interval_sec':
             LaunchConfiguration('interval_sec'),
+            'use_bus_time': LaunchConfiguration('use_bus_time'),
         }],
         output='screen')
 
@@ -76,6 +77,7 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument('interface', default_value='can0'),
         DeclareLaunchArgument('interval_sec', default_value='0.01'),
+        DeclareLaunchArgument('use_bus_time', default_value='false'),
         DeclareLaunchArgument('auto_configure', default_value='true'),
         DeclareLaunchArgument('auto_activate', default_value='true'),
         socket_can_receiver_node,

--- a/test/receiver.cpp
+++ b/test/receiver.cpp
@@ -54,7 +54,8 @@ TEST_F(DISABLED_receiver, basic_typed)
   {
     uint32_t receive_msg{};
     CanId receive_id{};
-    EXPECT_NO_THROW(receive_id = receiver_->receive(receive_msg, receive_timeout_));
+    int bus_time;
+    EXPECT_NO_THROW(std::tie(receive_id, bus_time) = receiver_->receive(receive_msg, receive_timeout_));
     EXPECT_EQ(receive_msg, send_msg);
     EXPECT_EQ(receive_id.length(), sizeof(send_msg));
     EXPECT_EQ(send_id.get(), receive_id.get());
@@ -83,8 +84,7 @@ TEST_F(DISABLED_receiver, ping_pong)
     EXPECT_NO_THROW(sender_->send(idx, send_id, send_timeout_)) << idx;
     {
       decltype(idx) receive_msg{};
-      CanId receive_id{};
-      receive_id = receiver_->receive(receive_msg, receive_timeout_);
+      auto [receive_id, bus_time] = receiver_->receive(receive_msg, receive_timeout_);
       EXPECT_EQ(receive_msg, idx);
       EXPECT_EQ(receive_id.length(), sizeof(idx));
       EXPECT_EQ(send_id.get(), receive_id.get());

--- a/test/receiver.cpp
+++ b/test/receiver.cpp
@@ -54,7 +54,7 @@ TEST_F(DISABLED_receiver, basic_typed)
   {
     uint32_t receive_msg{};
     CanId receive_id{};
-    int bus_time;
+    uint64_t bus_time;
     EXPECT_NO_THROW(std::tie(receive_id, bus_time) = receiver_->receive(receive_msg, receive_timeout_));
     EXPECT_EQ(receive_msg, send_msg);
     EXPECT_EQ(receive_id.length(), sizeof(send_msg));


### PR DESCRIPTION
added the ability to get the bus time for the can packet, versus using ros time when received

Currently returns the time stamp & CanId with a std::tuple, but discussed w @JWhitleyWork about returning it as part of the `CanId` struct instead.