### PR TITLE
Added bus time

### DIFF
--- a/include/ros2_socketcan/socket_can_common.hpp
+++ b/include/ros2_socketcan/socket_can_common.hpp
@@ -23,15 +23,6 @@
 #include <chrono>
 #include <string>
 
-/**
- * Convert timeval to microseconds from epoch
- * @param tv
- * @return epoch time
- */
-inline uint64_t tv2TimeStamp(struct timeval tv) {
-    return uint64_t(tv.tv_sec)*1e6 + tv.tv_usec;
-}
-
 namespace drivers
 {
 namespace socketcan
@@ -45,6 +36,8 @@ namespace socketcan
 int32_t bind_can_socket(const std::string & interface);
 /// Convert std::chrono duration to timeval (with microsecond resolution)
 struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept;
+/// Convert timeval to time in microseconds
+uint64_t from_timeval(const struct timeval tv) noexcept;
 /// Create a fd_set for use with select() that only contains the specified file descriptor
 fd_set single_set(int32_t file_descriptor) noexcept;
 

--- a/include/ros2_socketcan/socket_can_common.hpp
+++ b/include/ros2_socketcan/socket_can_common.hpp
@@ -23,6 +23,15 @@
 #include <chrono>
 #include <string>
 
+/**
+ * Convert timeval to microseconds from epoch
+ * @param tv
+ * @return epoch time
+ */
+inline uint64_t tv2TimeStamp(struct timeval tv) {
+    return uint64_t(tv.tv_sec)*1e6 + tv.tv_usec;
+}
+
 namespace drivers
 {
 namespace socketcan

--- a/include/ros2_socketcan/socket_can_id.hpp
+++ b/include/ros2_socketcan/socket_can_id.hpp
@@ -99,7 +99,7 @@ public:
   /// Get the length of the data; only nonzero on received data
   LengthT length() const noexcept;
 
-  uint64_t get_bus_time(){ return bus_time; }
+  uint64_t get_bus_time() {return bus_time;}
 
 private:
   SOCKETCAN_LOCAL CanId(const IdT id, const uint64_t bus_time, FrameType type, bool is_extended);

--- a/include/ros2_socketcan/socket_can_id.hpp
+++ b/include/ros2_socketcan/socket_can_id.hpp
@@ -63,13 +63,13 @@ public:
   // Default constructor: standard data frame with id 0
   CanId() = default;
   /// Directly set id, blindly taking whatever bytes are given
-  explicit CanId(const IdT raw_id, const LengthT data_length = 0U);
+  explicit CanId(const IdT raw_id, const uint64_t bus_time, const LengthT data_length = 0U);
   /// Sets ID
   /// \throw std::domain_error if id would get truncated
-  CanId(const IdT id, FrameType type, StandardFrame_);
+  CanId(const IdT id, const uint64_t bus_time, FrameType type, StandardFrame_);
   /// Sets ID
   /// \throw std::domain_error if id would get truncated
-  CanId(const IdT id, FrameType type, ExtendedFrame_);
+  CanId(const IdT id, const uint64_t bus_time, FrameType type, ExtendedFrame_);
 
   /// Sets bit 31 to 0
   CanId & standard() noexcept;
@@ -99,11 +99,14 @@ public:
   /// Get the length of the data; only nonzero on received data
   LengthT length() const noexcept;
 
+  uint64_t get_bus_time(){ return bus_time; }
+
 private:
-  SOCKETCAN_LOCAL CanId(const IdT id, FrameType type, bool is_extended);
+  SOCKETCAN_LOCAL CanId(const IdT id, const uint64_t bus_time, FrameType type, bool is_extended);
 
   IdT m_id{};
   LengthT m_data_length{};
+  uint64_t bus_time;
 };  // class CanId
 }  // namespace socketcan
 }  // namespace drivers

--- a/include/ros2_socketcan/socket_can_id.hpp
+++ b/include/ros2_socketcan/socket_can_id.hpp
@@ -18,9 +18,9 @@
 #ifndef ROS2_SOCKETCAN__SOCKET_CAN_ID_HPP_
 #define ROS2_SOCKETCAN__SOCKET_CAN_ID_HPP_
 
-#include <ros2_socketcan/visibility_control.hpp>
-
 #include <stdexcept>
+
+#include "ros2_socketcan/visibility_control.hpp"
 
 namespace drivers
 {

--- a/include/ros2_socketcan/socket_can_receiver.hpp
+++ b/include/ros2_socketcan/socket_can_receiver.hpp
@@ -18,13 +18,13 @@
 #ifndef ROS2_SOCKETCAN__SOCKET_CAN_RECEIVER_HPP_
 #define ROS2_SOCKETCAN__SOCKET_CAN_RECEIVER_HPP_
 
-#include <ros2_socketcan/visibility_control.hpp>
-#include <ros2_socketcan/socket_can_id.hpp>
-
 #include <array>
 #include <chrono>
 #include <cstring>
 #include <string>
+
+#include "ros2_socketcan/visibility_control.hpp"
+#include "ros2_socketcan/socket_can_id.hpp"
 
 namespace drivers
 {

--- a/include/ros2_socketcan/socket_can_receiver_node.hpp
+++ b/include/ros2_socketcan/socket_can_receiver_node.hpp
@@ -76,6 +76,7 @@ private:
   std::unique_ptr<SocketCanReceiver> receiver_;
   std::unique_ptr<std::thread> receiver_thread_;
   std::chrono::nanoseconds interval_ns_;
+  bool use_bus_time_;
 };
 }  // namespace socketcan
 }  // namespace drivers

--- a/include/ros2_socketcan/socket_can_receiver_node.hpp
+++ b/include/ros2_socketcan/socket_can_receiver_node.hpp
@@ -17,19 +17,19 @@
 #ifndef ROS2_SOCKETCAN__SOCKET_CAN_RECEIVER_NODE_HPP_
 #define ROS2_SOCKETCAN__SOCKET_CAN_RECEIVER_NODE_HPP_
 
-#include <ros2_socketcan/visibility_control.hpp>
-#include <ros2_socketcan/socket_can_receiver.hpp>
-
-#include <rclcpp/rclcpp.hpp>
-#include <rclcpp_components/register_node_macro.hpp>
-#include <rclcpp_lifecycle/lifecycle_node.hpp>
-#include <rosidl_runtime_cpp/message_initialization.hpp>
-#include <can_msgs/msg/frame.hpp>
-#include <lifecycle_msgs/msg/state.hpp>
-
 #include <memory>
 #include <thread>
 #include <string>
+
+#include "ros2_socketcan/visibility_control.hpp"
+#include "ros2_socketcan/socket_can_receiver.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+#include "can_msgs/msg/frame.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
 
 namespace lc = rclcpp_lifecycle;
 using LNI = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface;

--- a/include/ros2_socketcan/socket_can_sender.hpp
+++ b/include/ros2_socketcan/socket_can_sender.hpp
@@ -18,11 +18,11 @@
 #ifndef ROS2_SOCKETCAN__SOCKET_CAN_SENDER_HPP_
 #define ROS2_SOCKETCAN__SOCKET_CAN_SENDER_HPP_
 
-#include <ros2_socketcan/visibility_control.hpp>
-#include <ros2_socketcan/socket_can_id.hpp>
-
 #include <chrono>
 #include <string>
+
+#include "ros2_socketcan/visibility_control.hpp"
+#include "ros2_socketcan/socket_can_id.hpp"
 
 namespace drivers
 {

--- a/include/ros2_socketcan/socket_can_sender_node.hpp
+++ b/include/ros2_socketcan/socket_can_sender_node.hpp
@@ -17,18 +17,18 @@
 #ifndef ROS2_SOCKETCAN__SOCKET_CAN_SENDER_NODE_HPP_
 #define ROS2_SOCKETCAN__SOCKET_CAN_SENDER_NODE_HPP_
 
-#include <ros2_socketcan/visibility_control.hpp>
-#include <ros2_socketcan/socket_can_sender.hpp>
-
-#include <rclcpp/rclcpp.hpp>
-#include <rclcpp_components/register_node_macro.hpp>
-#include <rclcpp_lifecycle/lifecycle_node.hpp>
-#include <rosidl_runtime_cpp/message_initialization.hpp>
-#include <can_msgs/msg/frame.hpp>
-#include <lifecycle_msgs/msg/state.hpp>
-
 #include <memory>
 #include <string>
+
+#include "ros2_socketcan/visibility_control.hpp"
+#include "ros2_socketcan/socket_can_sender.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+#include "can_msgs/msg/frame.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
 
 namespace lc = rclcpp_lifecycle;
 using LNI = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface;

--- a/launch/socket_can_receiver.launch.py
+++ b/launch/socket_can_receiver.launch.py
@@ -38,6 +38,7 @@ def generate_launch_description():
             'interface': LaunchConfiguration('interface'),
             'interval_sec':
             LaunchConfiguration('interval_sec'),
+            'use_bus_time': LaunchConfiguration('use_bus_time'),
         }],
         output='screen')
 
@@ -76,6 +77,7 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument('interface', default_value='can0'),
         DeclareLaunchArgument('interval_sec', default_value='0.01'),
+        DeclareLaunchArgument('use_bus_time', default_value='false'),
         DeclareLaunchArgument('auto_configure', default_value='true'),
         DeclareLaunchArgument('auto_activate', default_value='true'),
         socket_can_receiver_node,

--- a/src/socket_can_common.cpp
+++ b/src/socket_can_common.cpp
@@ -88,6 +88,12 @@ struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+uint64_t from_timeval(const struct timeval tv) noexcept
+{
+    return static_cast<uint64_t>(tv.tv_sec)*1e6 + tv.tv_usec;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 fd_set single_set(int32_t file_descriptor) noexcept
 {
   fd_set descriptor_set;

--- a/src/socket_can_common.cpp
+++ b/src/socket_can_common.cpp
@@ -90,7 +90,7 @@ struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept
 ////////////////////////////////////////////////////////////////////////////////
 uint64_t from_timeval(const struct timeval tv) noexcept
 {
-    return static_cast<uint64_t>(tv.tv_sec)*1e6 + tv.tv_usec;
+  return static_cast<uint64_t>(tv.tv_sec) * 1e6 + tv.tv_usec;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/socket_can_id.cpp
+++ b/src/socket_can_id.cpp
@@ -37,20 +37,22 @@ constexpr CanId::IdT EXTENDED_ID_MASK = CAN_EFF_MASK;
 constexpr CanId::IdT STANDARD_ID_MASK = CAN_SFF_MASK;
 
 ////////////////////////////////////////////////////////////////////////////////
-CanId::CanId(const IdT raw_id, const LengthT data_length)
+CanId::CanId(const IdT raw_id, const uint64_t bus_time, const LengthT data_length)
 : m_id{raw_id},
-  m_data_length{data_length}
+  m_data_length{data_length},
+  bus_time(bus_time)
 {
   (void)frame_type();  // just to throw
 }
-CanId::CanId(const IdT id, FrameType type, StandardFrame_)
-: CanId{id, type, false} {}
+CanId::CanId(const IdT id, const uint64_t bus_time, FrameType type, StandardFrame_)
+: CanId{id, bus_time, type, false} {}
 
-CanId::CanId(const IdT id, FrameType type, ExtendedFrame_)
-: CanId{id, type, true} {}
+CanId::CanId(const IdT id, const uint64_t bus_time, FrameType type, ExtendedFrame_)
+: CanId{id, bus_time, type, true} {}
 
 ////////////////////////////////////////////////////////////////////////////////
-CanId::CanId(const IdT id, FrameType type, bool is_extended)
+CanId::CanId(const IdT id, const uint64_t bus_time, FrameType type, bool is_extended)
+: bus_time(bus_time)
 {
   // Set extended bit
   if (is_extended) {

--- a/src/socket_can_receiver.cpp
+++ b/src/socket_can_receiver.cpp
@@ -87,7 +87,7 @@ CanId SocketCanReceiver::receive(void * const data, const std::chrono::nanosecon
   // get bus timestamp
   struct timeval tv;
   ioctl(m_file_descriptor, SIOCGSTAMP, &tv);
-  uint64_t bus_time = tv2TimeStamp(tv);
+  uint64_t bus_time = from_timeval(tv);
 
   return CanId{frame.can_id, bus_time, data_length};
 }

--- a/src/socket_can_receiver.cpp
+++ b/src/socket_can_receiver.cpp
@@ -18,9 +18,12 @@
 #include "ros2_socketcan/socket_can_receiver.hpp"
 
 #include <unistd.h>  // for close()
+#include <sys/ioctl.h>
+#include <sys/types.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <linux/can.h>
+#include <linux/sockios.h>
 
 #include <cstring>
 #include <string>
@@ -80,7 +83,13 @@ CanId SocketCanReceiver::receive(void * const data, const std::chrono::nanosecon
   // Write
   const auto data_length = static_cast<CanId::LengthT>(frame.can_dlc);
   (void)std::memcpy(data, static_cast<void *>(&frame.data[0U]), data_length);
-  return CanId{frame.can_id, data_length};
+
+  // get bus timestamp
+  struct timeval tv;
+  ioctl(m_file_descriptor, SIOCGSTAMP, &tv);
+  uint64_t bus_time = tv2TimeStamp(tv);
+
+  return CanId{frame.can_id, bus_time, data_length};
 }
 
 }  // namespace socketcan

--- a/src/socket_can_receiver_node.cpp
+++ b/src/socket_can_receiver_node.cpp
@@ -122,7 +122,7 @@ void SocketCanReceiverNode::receive()
     }
 
     if (use_bus_time_) {
-      frame_msg.header.stamp = rclcpp::Time(static_cast<int64_t>(receive_id.get_bus_time()*1000U)) ;
+      frame_msg.header.stamp = rclcpp::Time(static_cast<int64_t>(receive_id.get_bus_time()*1000U));
     } else {
       frame_msg.header.stamp = this->now();
     }

--- a/src/socket_can_receiver_node.cpp
+++ b/src/socket_can_receiver_node.cpp
@@ -34,12 +34,14 @@ SocketCanReceiverNode::SocketCanReceiverNode(rclcpp::NodeOptions options)
 : lc::LifecycleNode("socket_can_receiver_node", options)
 {
   interface_ = this->declare_parameter("interface", "can0");
+  use_bus_time_ = this->declare_parameter<bool>("use_bus_time", false);
   double interval_sec = this->declare_parameter("interval_sec", 0.01);
   interval_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
     std::chrono::duration<double>(interval_sec));
 
   RCLCPP_INFO(this->get_logger(), "interface: %s", interface_.c_str());
   RCLCPP_INFO(this->get_logger(), "interval(s): %f", interval_sec);
+  RCLCPP_INFO(this->get_logger(), "use bus time: %d", use_bus_time_);
 }
 
 LNI::CallbackReturn SocketCanReceiverNode::on_configure(const lc::State & state)
@@ -118,7 +120,12 @@ void SocketCanReceiverNode::receive()
         interface_.c_str(), ex.what());
       continue;
     }
-    frame_msg.header.stamp = this->now();
+
+    if (use_bus_time_) {
+      frame_msg.header.stamp = rclcpp::Time(static_cast<int64_t>(receive_id.get_bus_time()*1000U)) ;
+    } else {
+      frame_msg.header.stamp = this->now();
+    }
     frame_msg.id = receive_id.identifier();
     frame_msg.is_rtr = (receive_id.frame_type() == FrameType::REMOTE);
     frame_msg.is_extended = receive_id.is_extended();

--- a/src/socket_can_receiver_node.cpp
+++ b/src/socket_can_receiver_node.cpp
@@ -122,7 +122,8 @@ void SocketCanReceiverNode::receive()
     }
 
     if (use_bus_time_) {
-      frame_msg.header.stamp = rclcpp::Time(static_cast<int64_t>(receive_id.get_bus_time()*1000U));
+      frame_msg.header.stamp =
+        rclcpp::Time(static_cast<int64_t>(receive_id.get_bus_time() * 1000U));
     } else {
       frame_msg.header.stamp = this->now();
     }

--- a/src/socket_can_sender_node.cpp
+++ b/src/socket_can_sender_node.cpp
@@ -102,8 +102,8 @@ void SocketCanSenderNode::on_frame(const can_msgs::msg::Frame::SharedPtr msg)
       type = FrameType::DATA;
     }
 
-    CanId send_id = msg->is_extended ? CanId(msg->id, type, ExtendedFrame) :
-      CanId(msg->id, type, StandardFrame);
+    CanId send_id = msg->is_extended ? CanId(msg->id, 0, type, ExtendedFrame) :
+      CanId(msg->id, 0, type, StandardFrame);
     try {
       sender_->send(msg->data.data(), msg->dlc, send_id, timeout_ns_);
     } catch (const std::exception & ex) {

--- a/test/receiver.cpp
+++ b/test/receiver.cpp
@@ -14,13 +14,13 @@
 //
 // Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 
-#include <ros2_socketcan/socket_can_receiver.hpp>
-#include <ros2_socketcan/socket_can_sender.hpp>
-
 #include <gtest/gtest.h>
 
 #include <chrono>
 #include <memory>
+
+#include "ros2_socketcan/socket_can_receiver.hpp"
+#include "ros2_socketcan/socket_can_sender.hpp"
 
 using drivers::socketcan::SocketCanReceiver;
 using drivers::socketcan::SocketCanSender;

--- a/test/sanity_checks.cpp
+++ b/test/sanity_checks.cpp
@@ -46,11 +46,17 @@ using drivers::socketcan::MAX_DATA_LENGTH;
 TEST(socket_can_basics, id_bad)
 {
   // Bad frame type
-  EXPECT_THROW(CanId{0x6000'0000U}, std::domain_error);
+  // had to re-write to use lambda to compile properly
+  const auto construct_bad_frame = []() -> auto {
+      constexpr CanId::IdT truncated_id = 0x6000'0000U;
+      return CanId{truncated_id, 0};
+  };
+  EXPECT_THROW(construct_bad_frame(), std::domain_error);
+
   // Standard truncation
   const auto construct = [](const auto frame) -> auto {
       constexpr CanId::IdT truncated_id = 0xFFFF'FFFFU;
-      return CanId{truncated_id, FrameType::DATA, frame};
+      return CanId{truncated_id, 0, FrameType::DATA, frame};
     };
   EXPECT_THROW(construct(StandardFrame), std::domain_error);
   EXPECT_THROW(construct(ExtendedFrame), std::domain_error);

--- a/test/sanity_checks.cpp
+++ b/test/sanity_checks.cpp
@@ -50,7 +50,7 @@ TEST(socket_can_basics, id_bad)
   const auto construct_bad_frame = []() -> auto {
       constexpr CanId::IdT truncated_id = 0x6000'0000U;
       return CanId{truncated_id, 0};
-  };
+    };
   EXPECT_THROW(construct_bad_frame(), std::domain_error);
 
   // Standard truncation

--- a/test/sanity_checks.cpp
+++ b/test/sanity_checks.cpp
@@ -24,14 +24,14 @@
 #include <linux/can.h>
 #include <linux/can/raw.h>
 
-#include <ros2_socketcan/socket_can_sender.hpp>
-#include <ros2_socketcan/socket_can_receiver.hpp>
-
 #include <gtest/gtest.h>
 #include <cstring>
 
 #include <memory>
 #include <string>
+
+#include "ros2_socketcan/socket_can_sender.hpp"
+#include "ros2_socketcan/socket_can_receiver.hpp"
 
 using drivers::socketcan::SocketCanSender;
 using drivers::socketcan::SocketCanReceiver;


### PR DESCRIPTION
added the ability to get the bus time for the can packet, versus using ros time when received; packs bus time as part of the can id struct

This packs the bus time in the `CanId` object vs returns it as a tuple. I'll let the maintainers decide which they prefer :) 

Tested w. a can replay on my machine, using canreplay on a virtual can bus

@JWhitleyWork 