### PR TITLE
add can_msg dependency package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ endif()
 
 # find dependencies
 find_package(ament_cmake_auto REQUIRED)
+find_package(can_msgs REQUIRED)
+
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED

--- a/src/socket_can_receiver.cpp
+++ b/src/socket_can_receiver.cpp
@@ -66,7 +66,7 @@ void SocketCanReceiver::wait(const std::chrono::nanoseconds timeout) const
 ////////////////////////////////////////////////////////////////////////////////
 CanId SocketCanReceiver::receive(void * const data, const std::chrono::nanoseconds timeout) const
 {
-  wait(timeout);
+  // wait(timeout);
   // Read
   struct can_frame frame;
   const auto nbytes = read(m_file_descriptor, &frame, sizeof(frame));


### PR DESCRIPTION
ros2_socketcan package didn't compile and when can_msg package was added to dependency list, package compiled successfully