### PR TITLE
Add can_msgs dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake_auto REQUIRED)
+find_package(can_msgs REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED


### PR DESCRIPTION
Without this, building the package fails with error:

```
/code/ros2_ws/src/ros2_socketcan/include/ros2_socketcan/socket_can_sender_node.hpp:30:10: fatal error: can_msgs/msg/frame.hpp: No such file or directory
   30 | #include <can_msgs/msg/frame.hpp>
```
I'm on Galactic, Ubuntu 20