### PR TITLE
fix previously received data remains

### DIFF
--- a/src/socket_can_receiver.cpp
+++ b/src/socket_can_receiver.cpp
@@ -81,7 +81,7 @@ CanId SocketCanReceiver::receive(void * const data, const std::chrono::nanosecon
     throw std::logic_error{"Message was wrong size"};
   }
   // Write
-  const auto data_length = static_cast<CanId::LengthT>(frame.can_dlc);
+  const auto data_length = static_cast<CanId::LengthT>(sizeof(frame.data));
   (void)std::memcpy(data, static_cast<void *>(&frame.data[0U]), data_length);
 
   // get bus timestamp


### PR DESCRIPTION
Relate https://github.com/autowarefoundation/ros2_socketcan/issues/17

# Description

If the DLC(Data Length Code) is less than 8, the previously received data remains in the "data" field of the topic sent by ros2_socketcan.  

When supporting multiple types of HW with the same CAN-ID but different DLCs(*see below for further details), unintended behavior may occur if garbage is included in the reception result of can_receiver.

*Description about "CAN-ID but different DLCs".
For example, there are two HWs, HW1 and HW2, and the specification of HW1's CAN-ID: 100h is as follows.

 - HW1(DLC=1)

| CAN-ID |DLC|data1|data2|data3|data4|data5|data6|data7|data8|
|--|--|--|--|--|--|--|--|--|--|
| 100h |1|lamp1 on|-|-|-|-|-|-|-|

In contrast to the above, if the HW2 CAN-ID: 100h specification is as follows, a malfunction may occur if the previously received data remains in the "data" field.

 - HW2(DLC=2)

| CAN-ID |DLC|data1|data2|data3|data4|data5|data6|data7|data8|
|--|--|--|--|--|--|--|--|--|--|
| 100h |2|lamp1 on/off|lamp2 on/off|-|-|-|-|-|-|

## Current problem
The data length for memcopy was the DLC value in `SocketCanReceiver::receive`.  
As a result, when receiving data with a DLC length of less than 8, the data after the DLC data length was not initialized, and the previously received data remained in the buffer.

## Countermeasures
Fixed data length to memcopy to be the size of the data field.

## Review Procedure
I have confirmed that the unused data fields have been initialized by the steps described in the issue.

 * Make sure the description is valid.
 * Make sure that what is described in the description matches the implementation.