### PR TITLE
SocketCAN filters

### DIFF
--- a/ros2_socketcan/include/ros2_socketcan/socket_can_common.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_common.hpp
@@ -38,10 +38,21 @@ namespace socketcan
 int32_t bind_can_socket(const std::string & interface);
 
 /// Set SocketCAN filters
-/// \param[in] fd File descriptor of socket
+/// \param[in] fd File descriptor of the socket
 /// \param[in] f_list List of filters to be applied.
 /// \throw std::runtime_error If filters couldn't be applied
 void set_can_filter(int32_t fd, const std::vector<struct can_filter> & f_list);
+
+/// Set SocketCAN error filter
+/// \param[in] fd File descriptor of the socket
+/// \param[in] err_mask Error mask to be applied as a filter
+void set_can_err_filter(int32_t fd, can_err_mask_t err_mask);
+
+/// Set filters joining option for SocketCAN. If set, all filters
+/// must match for the frame to be passed.
+/// \param[in] fd File descriptor of the socket
+/// \param[in] join_filters Should the filters be joined?
+void set_can_filter_join(int32_t fd, bool join_filters);
 
 /// Convert std::chrono duration to timeval (with microsecond resolution)
 struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept;

--- a/ros2_socketcan/include/ros2_socketcan/socket_can_common.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_common.hpp
@@ -19,9 +19,11 @@
 
 #include <sys/select.h>
 #include <sys/time.h>
+#include <linux/can.h>
 
 #include <chrono>
 #include <string>
+#include <vector>
 
 namespace drivers
 {
@@ -34,6 +36,13 @@ namespace socketcan
 /// \throw std::runtime_error If one of socket(), fnctl(), ioctl(), bind() failed
 /// \throw std::domain_error If the provided interface name is too long
 int32_t bind_can_socket(const std::string & interface);
+
+/// Set SocketCAN filters
+/// \param[in] fd File descriptor of socket
+/// \param[in] f_list List of filters to be applied.
+/// \throw std::runtime_error If filters couldn't be applied
+void set_can_filter(int32_t fd, const std::vector<struct can_filter> & f_list);
+
 /// Convert std::chrono duration to timeval (with microsecond resolution)
 struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept;
 /// Convert timeval to time in microseconds

--- a/ros2_socketcan/include/ros2_socketcan/socket_can_receiver.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_receiver.hpp
@@ -18,10 +18,12 @@
 #ifndef ROS2_SOCKETCAN__SOCKET_CAN_RECEIVER_HPP_
 #define ROS2_SOCKETCAN__SOCKET_CAN_RECEIVER_HPP_
 
+#include <linux/can.h>
 #include <array>
 #include <chrono>
 #include <cstring>
 #include <string>
+#include <vector>
 
 #include "ros2_socketcan/visibility_control.hpp"
 #include "ros2_socketcan/socket_can_id.hpp"
@@ -39,6 +41,11 @@ public:
   explicit SocketCanReceiver(const std::string & interface = "can0");
   /// Destructor
   ~SocketCanReceiver() noexcept;
+
+  /// Set SocketCAN filters
+  /// \param[in] filters List of filters to be applied.
+  /// \throw std::runtime_error If filters couldn't be applied
+  void SetCanFilters(const std::vector<struct can_filter> & filters);
 
   /// Receive CAN data
   /// \param[out] data A buffer to be written with data bytes. Must be at least 8 bytes in size

--- a/ros2_socketcan/include/ros2_socketcan/socket_can_receiver.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_receiver.hpp
@@ -42,10 +42,48 @@ public:
   /// Destructor
   ~SocketCanReceiver() noexcept;
 
+  /// Structure containing possible CAN filter options.
+  struct CanFilterList
+  {
+    std::vector<struct can_filter> filters;
+    can_err_mask_t error_mask = 0;
+    bool join_filters = false;
+
+    /// Default constructor
+    CanFilterList() = default;
+
+
+    /// \copydoc ParseFilters(const std::string & str)
+    explicit CanFilterList(const char * str);
+
+
+    /// \copydoc ParseFilters(const std::string & str)
+    explicit CanFilterList(const std::string & str);
+
+    /// Parse CAN filters string:\n
+    /// Filters:\n
+    /// Comma separated filters can be specified for each given CAN interface.\n
+    /// <can_id>:<can_mask>\n
+    ///         (matches when <received_can_id> & mask == can_id & mask)\n
+    /// <can_id>~<can_mask>\n
+    ///         (matches when <received_can_id> & mask != can_id & mask)\n
+    /// #<error_mask>\n
+    ///         (set error frame filter, see include/linux/can/error.h)\n
+    /// [j|J]\n
+    ///         (join the given CAN filters - logical AND semantic)\n
+    ///
+    /// CAN IDs, masks and data content are given and expected in hexadecimal values.
+    /// When can_id and can_mask are both 8 digits, they are assumed to be 29 bit EFF.
+    /// \param[in] str Input to be parsed.
+    /// \return Populated CanFilterList structure.
+    /// \throw std::runtime_error if string couldn't be parsed.
+    static CanFilterList ParseFilters(const std::string & str);
+  };
+
   /// Set SocketCAN filters
   /// \param[in] filters List of filters to be applied.
   /// \throw std::runtime_error If filters couldn't be applied
-  void SetCanFilters(const std::vector<struct can_filter> & filters);
+  void SetCanFilters(const CanFilterList & filters);
 
   /// Receive CAN data
   /// \param[out] data A buffer to be written with data bytes. Must be at least 8 bytes in size

--- a/ros2_socketcan/include/ros2_socketcan/socket_can_receiver.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_receiver.hpp
@@ -74,6 +74,7 @@ public:
     ///
     /// CAN IDs, masks and data content are given and expected in hexadecimal values.
     /// When can_id and can_mask are both 8 digits, they are assumed to be 29 bit EFF.
+    /// \see https://manpages.ubuntu.com/manpages/jammy/man1/candump.1.html
     /// \param[in] str Input to be parsed.
     /// \return Populated CanFilterList structure.
     /// \throw std::runtime_error if string couldn't be parsed.

--- a/ros2_socketcan/include/ros2_socketcan/socket_can_receiver_node.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_receiver_node.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <thread>
 #include <string>
+#include <vector>
 
 #include "ros2_socketcan/visibility_control.hpp"
 #include "ros2_socketcan/socket_can_receiver.hpp"
@@ -76,6 +77,7 @@ private:
   std::unique_ptr<SocketCanReceiver> receiver_;
   std::unique_ptr<std::thread> receiver_thread_;
   std::chrono::nanoseconds interval_ns_;
+  std::vector<struct can_filter> can_filters_;
   bool use_bus_time_;
 };
 }  // namespace socketcan

--- a/ros2_socketcan/include/ros2_socketcan/socket_can_receiver_node.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_receiver_node.hpp
@@ -77,7 +77,6 @@ private:
   std::unique_ptr<SocketCanReceiver> receiver_;
   std::unique_ptr<std::thread> receiver_thread_;
   std::chrono::nanoseconds interval_ns_;
-  std::vector<struct can_filter> can_filters_;
   bool use_bus_time_;
 };
 }  // namespace socketcan

--- a/ros2_socketcan/launch/socket_can_receiver.launch.py
+++ b/ros2_socketcan/launch/socket_can_receiver.launch.py
@@ -38,6 +38,7 @@ def generate_launch_description():
             'interface': LaunchConfiguration('interface'),
             'interval_sec':
             LaunchConfiguration('interval_sec'),
+            'filters': LaunchConfiguration('filters'),
             'use_bus_time': LaunchConfiguration('use_bus_time'),
         }],
         output='screen')
@@ -78,6 +79,9 @@ def generate_launch_description():
         DeclareLaunchArgument('interface', default_value='can0'),
         DeclareLaunchArgument('interval_sec', default_value='0.01'),
         DeclareLaunchArgument('use_bus_time', default_value='false'),
+        DeclareLaunchArgument('filters', default_value='[0,0]',
+                              description='Has to be multiple of 2 containing '
+                                          'pairs of [can_id:mask].'),
         DeclareLaunchArgument('auto_configure', default_value='true'),
         DeclareLaunchArgument('auto_activate', default_value='true'),
         socket_can_receiver_node,

--- a/ros2_socketcan/launch/socket_can_receiver.launch.py
+++ b/ros2_socketcan/launch/socket_can_receiver.launch.py
@@ -98,7 +98,10 @@ def generate_launch_description():
                                           'expected in hexadecimal values. When can_id and '
                                           'can_mask are both 8 digits, they are assumed to '
                                           "be 29 bit EFF. '0:0' default filter will accept "
-                                          'all data frames.'),
+                                          'all data frames.\n'
+                                          '\tFor more information about syntax check: '
+                                          'https://manpages.ubuntu.com/manpages/jammy/'
+                                          'man1/candump.1.html'),
         DeclareLaunchArgument('auto_configure', default_value='true'),
         DeclareLaunchArgument('auto_activate', default_value='true'),
         socket_can_receiver_node,

--- a/ros2_socketcan/launch/socket_can_receiver.launch.py
+++ b/ros2_socketcan/launch/socket_can_receiver.launch.py
@@ -79,9 +79,26 @@ def generate_launch_description():
         DeclareLaunchArgument('interface', default_value='can0'),
         DeclareLaunchArgument('interval_sec', default_value='0.01'),
         DeclareLaunchArgument('use_bus_time', default_value='false'),
-        DeclareLaunchArgument('filters', default_value='[0,0]',
-                              description='Has to be multiple of 2 containing '
-                                          'pairs of [can_id:mask].'),
+        DeclareLaunchArgument('filters', default_value='0:0',
+                              description='Comma separated filters can be specified for each given'
+                                          ' CAN interface.\n'
+                                          '\t<can_id>:<can_mask>\n'
+                                          '\t\t(matches when <received_can_id> & mask == can_id & '
+                                          'mask)\n'
+                                          '\t<can_id>~<can_mask>\n'
+                                          '\t\t(matches when <received_can_id> & mask != can_id & '
+                                          'mask)\n'
+                                          '\t#<error_mask>\n'
+                                          '\t\t(set error frame filter, see include/linux/can/'
+                                          'error.h)\n'
+                                          '\t[j|J]\n'
+                                          '\t\t(join the given CAN filters - logical AND '
+                                          'semantic)\n\n'
+                                          '\tCAN IDs, masks and data content are given and '
+                                          'expected in hexadecimal values. When can_id and '
+                                          'can_mask are both 8 digits, they are assumed to '
+                                          "be 29 bit EFF. '0:0' default filter will accept "
+                                          'all data frames.'),
         DeclareLaunchArgument('auto_configure', default_value='true'),
         DeclareLaunchArgument('auto_activate', default_value='true'),
         socket_can_receiver_node,

--- a/ros2_socketcan/src/socket_can_common.cpp
+++ b/ros2_socketcan/src/socket_can_common.cpp
@@ -89,6 +89,33 @@ void set_can_filter(int32_t fd, const std::vector<struct can_filter> & f_list)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+void set_can_err_filter(int32_t fd, can_err_mask_t err_mask)
+{
+  if (0 !=
+    setsockopt(
+      fd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask,
+      sizeof(err_mask)))
+  {
+    throw std::runtime_error{"Failed to set up CAN error filters: " +
+            std::string{strerror(errno)}};
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void set_can_filter_join(int32_t fd, bool join_filters)
+{
+  auto join = static_cast<int>(join_filters);
+  if (0 !=
+    setsockopt(
+      fd, SOL_CAN_RAW, CAN_RAW_JOIN_FILTERS, &join,
+      sizeof(join)))
+  {
+    throw std::runtime_error{"Failed to set up joined CAN filters: " +
+            std::string{strerror(errno)}};
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 struct timeval to_timeval(const std::chrono::nanoseconds timeout) noexcept
 {
   const auto count = timeout.count();

--- a/ros2_socketcan/src/socket_can_common.cpp
+++ b/ros2_socketcan/src/socket_can_common.cpp
@@ -29,6 +29,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace drivers
 {
@@ -73,6 +74,18 @@ int32_t bind_can_socket(const std::string & interface)
   //lint -restore NOLINT
 
   return file_descriptor;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void set_can_filter(int32_t fd, const std::vector<struct can_filter> & f_list)
+{
+  if (0 !=
+    setsockopt(
+      fd, SOL_CAN_RAW, CAN_RAW_FILTER, f_list.empty() ? NULL : f_list.data(),
+      sizeof(can_filter) * f_list.size()))
+  {
+    throw std::runtime_error{"Failed to set up CAN filters: " + std::string{strerror(errno)}};
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ros2_socketcan/src/socket_can_receiver.cpp
+++ b/ros2_socketcan/src/socket_can_receiver.cpp
@@ -27,7 +27,9 @@
 
 #include <cstring>
 #include <string>
+#include <sstream>
 #include <vector>
+#include <cstdio>
 
 namespace drivers
 {
@@ -48,9 +50,63 @@ SocketCanReceiver::~SocketCanReceiver() noexcept
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void SocketCanReceiver::SetCanFilters(const std::vector<struct can_filter> & filters)
+SocketCanReceiver::CanFilterList::CanFilterList(const char * str)
 {
-  set_can_filter(m_file_descriptor, filters);
+  *this = ParseFilters(str);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+SocketCanReceiver::CanFilterList::CanFilterList(const std::string & str)
+{
+  *this = ParseFilters(str);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+SocketCanReceiver::CanFilterList SocketCanReceiver::CanFilterList::ParseFilters(
+  const std::string & str)
+{
+  CanFilterList filter_list;
+  filter_list.error_mask = 0;
+  filter_list.join_filters = false;
+
+  std::istringstream input(str);
+  std::string fstr;
+
+  while (getline(input, fstr, ',')) {
+    // trim leading and trailing whitespaces
+    fstr = fstr.substr(
+      fstr.find_first_not_of(" \t"),
+      fstr.find_last_not_of(" \t") - fstr.find_first_not_of(" \t") + 1);
+
+    struct can_filter filter;
+    if (std::sscanf(fstr.c_str(), "%x:%x", &filter.can_id, &filter.can_mask) == 2) {
+      filter.can_mask &= ~CAN_ERR_FLAG;
+      if (fstr.size() > 8 && fstr[8] == ':') {
+        filter.can_id |= CAN_EFF_FLAG;
+      }
+      filter_list.filters.push_back(filter);
+    } else if (std::sscanf(fstr.c_str(), "%x~%x", &filter.can_id, &filter.can_mask) == 2) {
+      filter.can_id |= CAN_INV_FILTER;
+      filter.can_mask &= ~CAN_ERR_FLAG;
+      if (fstr.size() > 8 && fstr[8] == '~') {
+        filter.can_id |= CAN_EFF_FLAG;
+      }
+      filter_list.filters.push_back(filter);
+    } else if (fstr == "j" || fstr == "J") {
+      filter_list.join_filters = true;
+    } else if (std::sscanf(fstr.c_str(), "#%x", &filter_list.error_mask) != 1) {
+      throw std::runtime_error("Error during filter parsing: " + fstr);
+    }
+  }
+  return filter_list;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void SocketCanReceiver::SetCanFilters(const CanFilterList & filters)
+{
+  set_can_filter(m_file_descriptor, filters.filters);
+  set_can_err_filter(m_file_descriptor, filters.error_mask);
+  set_can_filter_join(m_file_descriptor, filters.join_filters);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ros2_socketcan/src/socket_can_receiver.cpp
+++ b/ros2_socketcan/src/socket_can_receiver.cpp
@@ -27,6 +27,7 @@
 
 #include <cstring>
 #include <string>
+#include <vector>
 
 namespace drivers
 {
@@ -44,6 +45,12 @@ SocketCanReceiver::~SocketCanReceiver() noexcept
 {
   // Can't do anything on error; in fact generally shouldn't on close() error
   (void)close(m_file_descriptor);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void SocketCanReceiver::SetCanFilters(const std::vector<struct can_filter> & filters)
+{
+  set_can_filter(m_file_descriptor, filters);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ros2_socketcan/src/socket_can_receiver_node.cpp
+++ b/ros2_socketcan/src/socket_can_receiver_node.cpp
@@ -20,7 +20,6 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <sstream>
 #include <vector>
 
 namespace lc = rclcpp_lifecycle;
@@ -38,33 +37,13 @@ SocketCanReceiverNode::SocketCanReceiverNode(rclcpp::NodeOptions options)
   interface_ = this->declare_parameter("interface", "can0");
   use_bus_time_ = this->declare_parameter<bool>("use_bus_time", false);
   double interval_sec = this->declare_parameter("interval_sec", 0.01);
-  auto filters_list = this->declare_parameter("filters", std::vector<int64_t>({0x0, 0x0}));
+  this->declare_parameter("filters", "0:0");
   interval_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
     std::chrono::duration<double>(interval_sec));
 
   RCLCPP_INFO(this->get_logger(), "interface: %s", interface_.c_str());
   RCLCPP_INFO(this->get_logger(), "interval(s): %f", interval_sec);
   RCLCPP_INFO(this->get_logger(), "use bus time: %d", use_bus_time_);
-
-  // create and print CAN filters list
-  if (filters_list.size() % 2 != 0) {
-    RCLCPP_WARN(
-      this->get_logger(),
-      "filters not applied as list lenght is not a multiple of 2 (id and mask)!");
-  } else {
-    std::ostringstream ss;
-    ss << std::hex;
-    for (std::size_t i = 0; i < filters_list.size(); i += 2) {
-      ss << "[" << filters_list[i] << ":" << filters_list[i + 1] << "]";
-      if (i + 2 != filters_list.size()) {
-        ss << ",";
-      }
-      can_filters_.push_back(
-        {static_cast<canid_t>(filters_list[i]),
-          static_cast<canid_t>(filters_list[i + 1])});  // push to filter list
-    }
-    RCLCPP_INFO(this->get_logger(), "filters [id:mask]: %s", ss.str().c_str());
-  }
 }
 
 LNI::CallbackReturn SocketCanReceiverNode::on_configure(const lc::State & state)
@@ -73,7 +52,10 @@ LNI::CallbackReturn SocketCanReceiverNode::on_configure(const lc::State & state)
 
   try {
     receiver_ = std::make_unique<SocketCanReceiver>(interface_);
-    receiver_->SetCanFilters(can_filters_);
+    // apply CAN filters
+    auto filters = get_parameter("filters").as_string();
+    receiver_->SetCanFilters(SocketCanReceiver::CanFilterList(filters));
+    RCLCPP_INFO(get_logger(), "applied filters: %s", filters.c_str());
   } catch (const std::exception & ex) {
     RCLCPP_ERROR(
       this->get_logger(), "Error opening CAN receiver: %s - %s",

--- a/ros2_socketcan/test/receiver.cpp
+++ b/ros2_socketcan/test/receiver.cpp
@@ -15,9 +15,11 @@
 // Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 
 #include <gtest/gtest.h>
+#include <linux/can/error.h>
 
 #include <chrono>
 #include <memory>
+#include <string>
 
 #include "ros2_socketcan/socket_can_receiver.hpp"
 #include "ros2_socketcan/socket_can_sender.hpp"
@@ -92,36 +94,150 @@ TEST_F(DISABLED_receiver, ping_pong)
   }
 }
 
+TEST_F(DISABLED_receiver, can_filters_parser)
+{
+  typedef SocketCanReceiver::CanFilterList CanFilterList;
+
+  auto filter_list = CanFilterList("101:7FF,333:ab,404:1,92345678:DFFFFFFF");
+  ASSERT_EQ(filter_list.filters.size(), 4U);
+  EXPECT_EQ(filter_list.filters[0].can_id, 0x101U);
+  EXPECT_EQ(filter_list.filters[0].can_mask, 0x7FFU);
+  EXPECT_EQ(filter_list.filters[1].can_id, 0x333U);
+  EXPECT_EQ(filter_list.filters[1].can_mask, 0xABU);
+  EXPECT_EQ(filter_list.filters[2].can_id, 0x404U);
+  EXPECT_EQ(filter_list.filters[2].can_mask, 0x1U);
+  EXPECT_EQ(filter_list.filters[3].can_id, 0x92345678U);
+  EXPECT_EQ(filter_list.filters[3].can_mask, 0xDFFFFFFFU);
+  EXPECT_EQ(filter_list.error_mask, 0x0U);
+  EXPECT_FALSE(filter_list.join_filters);
+
+  filter_list = CanFilterList("");
+  EXPECT_TRUE(filter_list.filters.empty());
+  EXPECT_EQ(filter_list.error_mask, 0x0U);
+  EXPECT_FALSE(filter_list.join_filters);
+  filter_list = CanFilterList("#12345");
+  EXPECT_TRUE(filter_list.filters.empty());
+  EXPECT_EQ(filter_list.error_mask, 0x12345U);
+  EXPECT_FALSE(filter_list.join_filters);
+
+  filter_list = CanFilterList("j");
+  EXPECT_TRUE(filter_list.filters.empty());
+  EXPECT_EQ(filter_list.error_mask, 0x0U);
+  EXPECT_TRUE(filter_list.join_filters);
+
+
+  filter_list = CanFilterList("0~0,#FFFFFFFF");
+  ASSERT_EQ(filter_list.filters.size(), 1U);
+  EXPECT_EQ(filter_list.filters[0].can_id, 0x0U | CAN_INV_FILTER);
+  EXPECT_EQ(filter_list.filters[0].can_mask, 0x0U);
+  EXPECT_EQ(filter_list.error_mask, 0xFFFFFFFFU);
+  EXPECT_FALSE(filter_list.join_filters);
+
+  filter_list = CanFilterList("1:2,3~4,5:6,7~8,9:A,j");
+  ASSERT_EQ(filter_list.filters.size(), 5U);
+  EXPECT_EQ(filter_list.filters[0].can_id, 0x1U);
+  EXPECT_EQ(filter_list.filters[0].can_mask, 0x2U);
+  EXPECT_EQ(filter_list.filters[1].can_id, 0x3U | CAN_INV_FILTER);
+  EXPECT_EQ(filter_list.filters[1].can_mask, 0x4U);
+  EXPECT_EQ(filter_list.filters[2].can_id, 0x5U);
+  EXPECT_EQ(filter_list.filters[2].can_mask, 0x6U);
+  EXPECT_EQ(filter_list.filters[3].can_id, 0x7U | CAN_INV_FILTER);
+  EXPECT_EQ(filter_list.filters[3].can_mask, 0x8U);
+  EXPECT_EQ(filter_list.filters[4].can_id, 0x9U);
+  EXPECT_EQ(filter_list.filters[4].can_mask, 0xAU);
+  EXPECT_EQ(filter_list.error_mask, 0x0U);
+  EXPECT_TRUE(filter_list.join_filters);
+
+  filter_list = CanFilterList("ABC:DEF,123:C00007FF,J,#5");
+  ASSERT_EQ(filter_list.filters.size(), 2U);
+  EXPECT_EQ(filter_list.filters[0].can_id, 0xABCU);
+  EXPECT_EQ(filter_list.filters[0].can_mask, 0xDEFU);
+  EXPECT_EQ(filter_list.filters[1].can_id, 0x123U);
+  EXPECT_EQ(filter_list.filters[1].can_mask, 0xC00007FFU);
+  EXPECT_EQ(filter_list.error_mask, 0x5U);
+  EXPECT_TRUE(filter_list.join_filters);
+
+  // whitespace trimming test
+  filter_list = CanFilterList(
+    "        ABC:DEF             , 123:C00007FF       ,         J   ,    #5    ");
+  ASSERT_EQ(filter_list.filters.size(), 2U);
+  EXPECT_EQ(filter_list.filters[0].can_id, 0xABCU);
+  EXPECT_EQ(filter_list.filters[0].can_mask, 0xDEFU);
+  EXPECT_EQ(filter_list.filters[1].can_id, 0x123U);
+  EXPECT_EQ(filter_list.filters[1].can_mask, 0xC00007FFU);
+  EXPECT_EQ(filter_list.error_mask, 0x5U);
+  EXPECT_TRUE(filter_list.join_filters);
+
+  // test incorrect input
+  std::string str = "        ABC:DEF             , 123:C00007FF       ,         J   ,    #p5    ";
+  EXPECT_THROW(CanFilterList::ParseFilters(str), std::runtime_error);
+  str = "1:2,3~4,5:6,7~8,9:A,l";
+  EXPECT_THROW(CanFilterList::ParseFilters(str), std::runtime_error);
+  str = "1:2,3~4,5;6,7~8,9:A,j";
+  EXPECT_THROW(CanFilterList::ParseFilters(str), std::runtime_error);
+  str = "1:2,3 ~4,5:6,7~8,9:A,j";
+  EXPECT_THROW(CanFilterList::ParseFilters(str), std::runtime_error);
+  str = "not a correct string";
+  EXPECT_THROW(CanFilterList::ParseFilters(str), std::runtime_error);
+}
+
 TEST_F(DISABLED_receiver, can_filters)
 {
   constexpr uint32_t send_msg = 0x5A'5A'5A'5AU;
+  SocketCanReceiver::CanFilterList filter_list;
 
-  // pass only ids: 0x100, 0x250, 0x555
-  receiver_->SetCanFilters({{0x100, 0x7FF}, {0x250, 0x7FF}, {0x555, 0x7FF}});
+  ////////////////////////////////////////////////////////////////////////////////
+  // pass only ids: 0x100, 0x250, 0x555 of standard length
+  filter_list.filters = {{0x100, 0xC00007FF}, {0x250, 0xC00007FF}, {0x555, 0xC00007FF}};
+  receiver_->SetCanFilters(filter_list);
   CanId send_id{};
-  send_id.standard();
 
+  // error frame should be blocked
+  send_id.error_frame();
+  send_id.identifier(static_cast<CanId::IdT>(0x100U));
+  sender_->send(send_msg, send_id, send_timeout_);
+
+  // RTR frame should be blocked
+  send_id.remote_frame();
+  send_id.standard();
+  send_id.identifier(static_cast<CanId::IdT>(0x100U));
+  sender_->send(send_msg, send_id, send_timeout_);
+
+  // extended data frame should be blocked
+  send_id.data_frame();
+  send_id.extended();
+  send_id.identifier(static_cast<CanId::IdT>(0x100U));
+  sender_->send(send_msg, send_id, send_timeout_);
+
+  // wrong ids - should be blocked
+  send_id.data_frame();
+  send_id.standard();
   for (uint32_t idx = 0x50U; idx < 0x100U; idx++) {
     send_id.identifier(static_cast<CanId::IdT>(idx));
     sender_->send(send_msg, send_id, send_timeout_);
   }
 
+  // should pass
   send_id.identifier(static_cast<CanId::IdT>(0x100U));
   sender_->send(send_msg, send_id, send_timeout_);
 
+  // wrong ids - should be blocked
   for (uint32_t idx = 0x200U; idx < 0x250U; idx++) {
     send_id.identifier(static_cast<CanId::IdT>(idx));
     sender_->send(send_msg, send_id, send_timeout_);
   }
 
+  // should pass
   send_id.identifier(static_cast<CanId::IdT>(0x250U));
   sender_->send(send_msg, send_id, send_timeout_);
 
+  // wrong ids - should be blocked
   for (uint32_t idx = 0x500U; idx < 0x550U; idx++) {
     send_id.identifier(static_cast<CanId::IdT>(idx));
     sender_->send(send_msg, send_id, send_timeout_);
   }
 
+  // should pass
   send_id.identifier(static_cast<CanId::IdT>(0x555U));
   sender_->send(send_msg, send_id, send_timeout_);
 
@@ -129,13 +245,21 @@ TEST_F(DISABLED_receiver, can_filters)
   CanId receive_id{};
   receive_id = receiver_->receive(receive_msg, receive_timeout_);
   EXPECT_EQ(0x100U, receive_id.get());
+  EXPECT_FALSE(receive_id.is_extended());
+  EXPECT_EQ(receive_id.frame_type(), FrameType::DATA);
   receive_id = receiver_->receive(receive_msg, receive_timeout_);
   EXPECT_EQ(0x250U, receive_id.get());
+  EXPECT_FALSE(receive_id.is_extended());
+  EXPECT_EQ(receive_id.frame_type(), FrameType::DATA);
   receive_id = receiver_->receive(receive_msg, receive_timeout_);
   EXPECT_EQ(0x555U, receive_id.get());
+  EXPECT_FALSE(receive_id.is_extended());
+  EXPECT_EQ(receive_id.frame_type(), FrameType::DATA);
 
+  ////////////////////////////////////////////////////////////////////////////////
   // pass only even ids
-  receiver_->SetCanFilters({{0x0, 0x1}});
+  filter_list.filters = {{0x0, 0x1}};
+  receiver_->SetCanFilters(filter_list);
   send_id.extended();
   for (uint32_t idx = 0x1000U; idx < 0x1050U; idx++) {
     send_id.identifier(static_cast<CanId::IdT>(idx));
@@ -143,11 +267,14 @@ TEST_F(DISABLED_receiver, can_filters)
     if (idx % 2 == 0) {
       receive_id = receiver_->receive(receive_msg, receive_timeout_);
       EXPECT_EQ(send_id.get(), receive_id.get());
+      EXPECT_EQ(send_id.frame_type(), FrameType::DATA);
     }
   }
 
+  ////////////////////////////////////////////////////////////////////////////////
   // pass none ids
-  receiver_->SetCanFilters({});
+  filter_list.filters = {};
+  receiver_->SetCanFilters(filter_list);
   send_id.standard();
   for (uint32_t idx = 0x300U; idx < 0x330U; idx++) {
     send_id.identifier(static_cast<CanId::IdT>(idx));
@@ -155,13 +282,106 @@ TEST_F(DISABLED_receiver, can_filters)
   }
   EXPECT_THROW(receive_id = receiver_->receive(receive_msg, receive_timeout_), std::runtime_error);
 
-  // pass all frames
-  receiver_->SetCanFilters({{0x0, 0x0}});
+  ////////////////////////////////////////////////////////////////////////////////
+  // pass all frames (including errors and remotes)
+  filter_list.filters = {{0x0, 0x0}};
+  filter_list.error_mask = 0xFFFFFFFFU;
+  receiver_->SetCanFilters(filter_list);
   send_id.standard();
   for (uint32_t idx = 0x300U; idx < 0x330U; idx++) {
     send_id.identifier(static_cast<CanId::IdT>(idx));
     sender_->send(send_msg, send_id, send_timeout_);
     receive_id = receiver_->receive(receive_msg, receive_timeout_);
     EXPECT_EQ(send_id.get(), receive_id.get());
+    EXPECT_EQ(send_id.frame_type(), FrameType::DATA);
+  }
+  send_id.error_frame();
+  for (uint32_t idx = 0x200U; idx < 0x230U; idx++) {
+    send_id.identifier(static_cast<CanId::IdT>(idx));
+    sender_->send(send_msg, send_id, send_timeout_);
+    receive_id = receiver_->receive(receive_msg, receive_timeout_);
+    EXPECT_EQ(send_id.get(), receive_id.get());
+    EXPECT_EQ(send_id.frame_type(), FrameType::ERROR);
+  }
+  send_id.remote_frame();
+  for (uint32_t idx = 0x100U; idx < 0x130U; idx++) {
+    send_id.identifier(static_cast<CanId::IdT>(idx));
+    sender_->send(send_msg, send_id, send_timeout_);
+    receive_id = receiver_->receive(receive_msg, receive_timeout_);
+    EXPECT_EQ(send_id.get(), receive_id.get());
+    EXPECT_EQ(send_id.frame_type(), FrameType::REMOTE);
+  }
+
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // JOIN FILTERS: pass only CAN_ERR_TX_TIMEOUT and CAN_ERR_BUSOFF error frames
+  // filter_list.filters = {{0x0, 0x0 | CAN_INV_FILTER}};
+  // filter_list.error_mask = (CAN_ERR_TX_TIMEOUT | CAN_ERR_BUSOFF);
+  // receiver_->SetCanFilters(filter_list);
+  receiver_->SetCanFilters(SocketCanReceiver::CanFilterList("0~0,#41"));  // same as above comment
+
+  // should be blocked
+  for (uint32_t idx = 0x300U; idx < 0x330U; idx++) {
+    send_id.identifier(static_cast<CanId::IdT>(idx));
+    sender_->send(send_msg, send_id, send_timeout_);
+  }
+
+  // should pass
+  send_id.error_frame();
+  send_id.identifier(static_cast<CanId::IdT>(CAN_ERR_TX_TIMEOUT));
+  sender_->send(send_msg, send_id, send_timeout_);
+  receive_id = receiver_->receive(receive_msg, receive_timeout_);
+  EXPECT_EQ(send_id.get(), receive_id.get());
+  EXPECT_EQ(send_id.frame_type(), FrameType::ERROR);
+
+  // should be blocked
+  send_id.identifier(static_cast<CanId::IdT>(CAN_ERR_ACK));
+  sender_->send(send_msg, send_id, send_timeout_);
+
+  // should pass
+  send_id.error_frame();
+  send_id.identifier(static_cast<CanId::IdT>(CAN_ERR_BUSOFF));
+  sender_->send(send_msg, send_id, send_timeout_);
+  receive_id = receiver_->receive(receive_msg, receive_timeout_);
+  EXPECT_EQ(send_id.get(), receive_id.get());
+  EXPECT_EQ(send_id.frame_type(), FrameType::ERROR);
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // JOIN FILTERS: pass only even id data and remote frames from 0x400 to 0x499
+  filter_list.filters = {{0x0, 0x1}, {0x400, 0x700}};
+  filter_list.error_mask = 0;
+  filter_list.join_filters = true;
+  receiver_->SetCanFilters(filter_list);
+
+  send_id.data_frame();
+  send_id.standard();
+
+  // should be blocked
+  for (uint32_t idx = 0x300U; idx < 0x330U; idx++) {
+    send_id.identifier(static_cast<CanId::IdT>(idx));
+    sender_->send(send_msg, send_id, send_timeout_);
+  }
+
+  // only even should pass
+  for (uint32_t idx = 0x400U; idx < 0x500U; idx++) {
+    send_id.identifier(static_cast<CanId::IdT>(idx));
+    sender_->send(send_msg, send_id, send_timeout_);
+    if (idx % 2 == 0) {
+      receive_id = receiver_->receive(receive_msg, receive_timeout_);
+      EXPECT_EQ(send_id.get(), receive_id.get());
+      EXPECT_EQ(send_id.frame_type(), FrameType::DATA);
+    }
+  }
+
+  // only even should pass
+  send_id.remote_frame();
+  for (uint32_t idx = 0x400U; idx < 0x500U; idx++) {
+    send_id.identifier(static_cast<CanId::IdT>(idx));
+    sender_->send(send_msg, send_id, send_timeout_);
+    if (idx % 2 == 0) {
+      receive_id = receiver_->receive(receive_msg, receive_timeout_);
+      EXPECT_EQ(send_id.get(), receive_id.get());
+      EXPECT_EQ(send_id.frame_type(), FrameType::REMOTE);
+    }
   }
 }


### PR DESCRIPTION
# CAN filters support.
A list of  SocketCAN filters can be applied to the receiver. This allows for software filtering of unwanted messages on the socket level, reducing communication overhead when applicable.

Filters can be applied to receiver node using ROS2 parameter. `filters` parameter accepts a string of filters which is parsed by the receiver and applied on configuration of the node. By default, socket_can_receiver.launch.py will apply a filter which accepts all data frames, though it can be changed using `filters` launch argument.

## Filters

Full support for all 3 socket options of filtering (`CAN_RAW_FILTER`, `CAN_RAW_ERR_FILTER` and `CAN_RAW_JOIN_FILTERS`) has been added. Filter encoding is exactly the same as for [_canutils' candump_](https://manpages.ubuntu.com/manpages/jammy/man1/candump.1.html):

```
Filters:
 Comma separated filters can be specified for each given CAN interface.
<can_id>:<can_mask>
        (matches when <received_can_id> & mask == can_id & mask)
<can_id>~<can_mask>
        (matches when <received_can_id> & mask != can_id & mask)
#<error_mask>
        (set error frame filter, see include/linux/can/error.h)
[j|J]
        (join the given CAN filters - logical AND semantic)

CAN IDs, masks and data content are given and expected in hexadecimal values.
When can_id and can_mask are both 8 digits, they are assumed to be 29 bit EFF.
```



### Examples of filters

- `123:C00007FF` will pass only frames with id 0x123 of standard length. RTR frames will not be passed.
- `123:3FFFFFFF` will pass standard and extended frames with id 0x123. It will also pass RTR frames of this id.
- `0:1` will pass only frames with even id (SFF, EFF and RTR).
- `400:FFFFFF00` will pass standard frames with id 0x400-0x499.
- `0:0` will pass only all frames.
- `0~0,#FFFFFFFF` will pass none of data fames, but will pass all error frames.
- `400:FFFFFF00,0:1` will pass all standard frames with if id 0x400-0x499 and all frames (extended and remote inlcuded) of even id.
- `400:FFFFFF00,0:1,j` will pass only standard frames with even id from 0x400-0x499 (e.g. 0x402 will pass but 0x403 will not)

## Usage

Using launch system:
```bash
$ ros2 launch ros2_socketcan socket_can_receiver.launch.py interface:=vcan0 filters:=101:7FF,103:7FF,0:1
[INFO] [launch]: All log files can be found below /home/marcel/.ros/log/2022-10-28-21-58-31-844506-marcel-ubuntu-55568
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [socket_can_receiver_node_exe-1]: process started with pid [55580]
[socket_can_receiver_node_exe-1] [INFO] [1666987111.956802116] [socket_can_receiver]: interface: vcan0
[socket_can_receiver_node_exe-1] [INFO] [1666987111.956856888] [socket_can_receiver]: interval(s): 0.010000
[socket_can_receiver_node_exe-1] [INFO] [1666987111.956871573] [socket_can_receiver]: use bus time: 0
[socket_can_receiver_node_exe-1] [INFO] [1666987112.191972338] [socket_can_receiver]: applied filters: 101:7FF,103:7FF,0:1
```

Using run:
```bash
$ ros2 run ros2_socketcan socket_can_receiver_node_exe --ros-args -p interface:=vcan0 -p filters:=101:7FF,103:7FF,0:1
[INFO] [1666987156.565628503] [socket_can_receiver_node]: interface: vcan0
[INFO] [1666987156.565686626] [socket_can_receiver_node]: interval(s): 0.010000
[INFO] [1666987156.565701169] [socket_can_receiver_node]: use bus time: 0
[INFO] [1666987191.144435937] [socket_can_receiver_node]: applied filters: 101:7FF,103:7FF,0:1
```