### PR TITLE
Allow remapping of the canbus topics

### DIFF
--- a/ros2_socketcan/launch/socket_can_bridge.launch.xml
+++ b/ros2_socketcan/launch/socket_can_bridge.launch.xml
@@ -4,17 +4,21 @@
   <arg name="receiver_interval_sec" default="0.01" />
   <arg name="sender_timeout_sec" default="0.01" />
   <arg name="enable_can_fd" default="false" />
+  <arg name="from_can_bus_topic" default="from_can_bus" />
+  <arg name="to_can_bus_topic" default="to_can_bus" />
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py">
     <arg name="interface" value="$(var interface)" />
     <arg name="interval_sec" value="$(var receiver_interval_sec)" />
     <arg name="enable_can_fd" value="$(var enable_can_fd)" />
+    <arg name="from_can_bus_topic" value="$(var from_can_bus_topic)" />
   </include>
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_sender.launch.py">
     <arg name="interface" value="$(var interface)" />
     <arg name="timeout_sec" value="$(var sender_timeout_sec)" />
     <arg name="enable_can_fd" value="$(var enable_can_fd)" />
+    <arg name="to_can_bus_topic" value="$(var to_can_bus_topic)" />
   </include>
 
 </launch>

--- a/ros2_socketcan/launch/socket_can_receiver.launch.py
+++ b/ros2_socketcan/launch/socket_can_receiver.launch.py
@@ -42,6 +42,7 @@ def generate_launch_description():
             'filters': LaunchConfiguration('filters'),
             'use_bus_time': LaunchConfiguration('use_bus_time'),
         }],
+        remappings=[('from_can_bus', LaunchConfiguration('from_can_bus_topic'))],
         output='screen')
 
     socket_can_receiver_configure_event_handler = RegisterEventHandler(
@@ -106,6 +107,7 @@ def generate_launch_description():
                                           'man1/candump.1.html'),
         DeclareLaunchArgument('auto_configure', default_value='true'),
         DeclareLaunchArgument('auto_activate', default_value='true'),
+        DeclareLaunchArgument('from_can_bus_topic', default_value='from_can_bus'),
         socket_can_receiver_node,
         socket_can_receiver_configure_event_handler,
         socket_can_receiver_activate_event_handler,

--- a/ros2_socketcan/launch/socket_can_sender.launch.py
+++ b/ros2_socketcan/launch/socket_can_sender.launch.py
@@ -40,6 +40,7 @@ def generate_launch_description():
             'timeout_sec':
             LaunchConfiguration('timeout_sec'),
         }],
+        remappings=[('to_can_bus', LaunchConfiguration('to_can_bus_topic'))],
         output='screen')
 
     socket_can_sender_configure_event_handler = RegisterEventHandler(
@@ -80,6 +81,7 @@ def generate_launch_description():
         DeclareLaunchArgument('timeout_sec', default_value='0.01'),
         DeclareLaunchArgument('auto_configure', default_value='true'),
         DeclareLaunchArgument('auto_activate', default_value='true'),
+        DeclareLaunchArgument('to_can_bus_topic', default_value='to_can_bus'),
         socket_can_sender_node,
         socket_can_sender_configure_event_handler,
         socket_can_sender_activate_event_handler,


### PR DESCRIPTION
Our codebase expects a `can/tx` and `can/rx` notation. In ros1 we could simply remap in the node.

However launching a bridge nowadays seems to involve 227 lines of launching :smile:.

We're rather not duplicate all those so kindly request to be able to set the topic via an argument.