### PR TITLE
fix: checking can id

### DIFF
--- a/ros2_socketcan/src/socket_can_id.cpp
+++ b/ros2_socketcan/src/socket_can_id.cpp
@@ -136,8 +136,13 @@ CanId & CanId::identifier(const IdT id)
   constexpr auto MAX_STANDARD = 0x07EFU;
   static_assert(MAX_EXTENDED <= EXTENDED_ID_MASK, "Max extended id value is wrong");
   static_assert(MAX_STANDARD <= STANDARD_ID_MASK, "Max extended id value is wrong");
-  const auto max_id = is_extended() ? MAX_EXTENDED : MAX_STANDARD;
-  if (max_id < id) {
+  auto max_id = MAX_STANDARD;
+  auto unmasked_id = id;
+  if (is_extended()) {
+    max_id = MAX_EXTENDED;
+    unmasked_id = id & ~(EXTENDED_MASK);
+  }
+  if (max_id < unmasked_id) {
     throw std::domain_error{"CanId would be truncated!"};
   }
   // Clear and set


### PR DESCRIPTION
## Description

At the Extended Can ID, the most significant bit determines the EFF flag (CAN_EFF_FLAG). For example, if our Extended CAN ID will be:
0x01F0A020 (00000001111100001010000000100000)
and if it's EFF Flag is 1, the value will be
0x81F0A020 (10000001111100001010000000100000).

Therefore, the CAN ID value is exceeds the 29 bit max value. (~536million - 0x1FBF'FFFFU). If we want to check can id value, we need to unmask it first. This PR fixes this problem.