### PR TITLE
Add missing header

### DIFF
--- a/ros2_socketcan/include/ros2_socketcan/socket_can_common.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_common.hpp
@@ -22,6 +22,7 @@
 #include <linux/can.h>
 
 #include <chrono>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/ros2_socketcan/include/ros2_socketcan/socket_can_id.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_id.hpp
@@ -18,6 +18,7 @@
 #ifndef ROS2_SOCKETCAN__SOCKET_CAN_ID_HPP_
 #define ROS2_SOCKETCAN__SOCKET_CAN_ID_HPP_
 
+#include <cstdint>
 #include <stdexcept>
 
 #include "ros2_socketcan/visibility_control.hpp"

--- a/ros2_socketcan/include/ros2_socketcan/socket_can_receiver.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_receiver.hpp
@@ -21,6 +21,7 @@
 #include <linux/can.h>
 #include <array>
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <vector>

--- a/ros2_socketcan/include/ros2_socketcan/socket_can_sender.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_sender.hpp
@@ -19,6 +19,7 @@
 #define ROS2_SOCKETCAN__SOCKET_CAN_SENDER_HPP_
 
 #include <chrono>
+#include <cstdint>
 #include <string>
 
 #include "ros2_socketcan/visibility_control.hpp"


### PR DESCRIPTION
Not having this header has been causing build failures in `rolling` and won't hurt any earlier releases.