### PR TITLE
fix: use find_package to fix rolling build error

### DIFF
--- a/ros2_socketcan/CMakeLists.txt
+++ b/ros2_socketcan/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 # find dependencies
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
+find_package(can_msgs REQUIRED)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/socket_can_common.cpp


### PR DESCRIPTION
Follow up from:
- https://github.com/autowarefoundation/ros2_socketcan/pull/42

Attempts to fix:
- https://github.com/autowarefoundation/ros2_socketcan/actions/runs/8421904097/job/23059902100?pr=42#step:5:371

I don't know why is this necessary but without `find_package(can_msgs REQUIRED)` it cannot build with rolling.