### PR TITLE
ci(build_test.yml): update the rolling to noble

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -31,7 +31,7 @@ jobs:
             ros_distribution: humble
             ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-rolling-ros-base-latest
+          - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
             ros_distribution: rolling
             ros_version: 2
     container:


### PR DESCRIPTION
Follow up from related PRs:
- https://github.com/autowarefoundation/ros2_socketcan/pull/42
- https://github.com/autowarefoundation/ros2_socketcan/pull/43

Source of problem:
- https://github.com/autowarefoundation/ros2_socketcan/actions/runs/8421904097/job/23059902100?pr=42#step:5:388
   - `fatal error: can_msgs/msg/frame.hpp: No such file or directory`
- https://github.com/autowarefoundation/ros2_socketcan/actions/runs/8421904097/job/23059902100?pr=42#step:5:92
   - `ros2_socketcan: No definition of [can_msgs] for OS version [jammy]`
- https://github.com/ros/rosdistro/blob/0da87fa41d858862aac6e743d59d3c49e235cd7c/rolling/distribution.yaml#L11
   - rolling now uses `noble`

Therefore I'm updating the CI to use noble for rolling.