### PR TITLE
fix(socket_can_receiver): support variable-length CAN FD frames

### DIFF
--- a/ros2_socketcan/launch/socket_can_bridge.launch.xml
+++ b/ros2_socketcan/launch/socket_can_bridge.launch.xml
@@ -6,12 +6,14 @@
   <arg name="enable_can_fd" default="false" />
   <arg name="from_can_bus_topic" default="from_can_bus" />
   <arg name="to_can_bus_topic" default="to_can_bus" />
+  <arg name="use_bus_time" default="false" />
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py">
     <arg name="interface" value="$(var interface)" />
     <arg name="interval_sec" value="$(var receiver_interval_sec)" />
     <arg name="enable_can_fd" value="$(var enable_can_fd)" />
     <arg name="from_can_bus_topic" value="$(var from_can_bus_topic)" />
+    <arg name="use_bus_time" value="$(var use_bus_time)" />
   </include>
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_sender.launch.py">

--- a/ros2_socketcan/src/socket_can_receiver.cpp
+++ b/ros2_socketcan/src/socket_can_receiver.cpp
@@ -171,18 +171,17 @@ CanId SocketCanReceiver::receive_fd(void * const data, const std::chrono::nanose
   // Read
   struct canfd_frame frame;
   const auto nbytes = read(m_file_descriptor, &frame, sizeof(frame));
+  const auto data_length = static_cast<CanId::LengthT>(frame.len);
+  const auto expected_length = sizeof(frame) - sizeof(frame.data) + data_length;
+
   // Checks
   if (nbytes < 0) {
     throw std::runtime_error{strerror(errno)};
   }
-  if (static_cast<std::size_t>(nbytes) < sizeof(frame)) {
+  if (static_cast<std::size_t>(nbytes) < expected_length) {
     throw std::runtime_error{"read: incomplete CAN FD frame"};
   }
-  if (static_cast<std::size_t>(nbytes) != sizeof(frame)) {
-    throw std::logic_error{"Message was wrong size"};
-  }
   // Write
-  const auto data_length = static_cast<CanId::LengthT>(frame.len);
   (void)std::memcpy(data, static_cast<void *>(&frame.data[0U]), data_length);
 
   // get bus timestamp

--- a/ros2_socketcan/src/socket_can_receiver.cpp
+++ b/ros2_socketcan/src/socket_can_receiver.cpp
@@ -177,6 +177,10 @@ CanId SocketCanReceiver::receive_fd(void * const data, const std::chrono::nanose
     throw std::runtime_error{strerror(errno)};
   }
 
+  if (frame.len > CANFD_MAX_DLEN) {
+    throw std::runtime_error{"read: frame length is larger than max allowed CAN FD payload length"};
+  }
+
   if (static_cast<std::size_t>(nbytes) < sizeof(frame.can_id) + sizeof(frame.len)) {
     throw std::runtime_error{"read: corrupted CAN frame"};
   }

--- a/ros2_socketcan/src/socket_can_receiver.cpp
+++ b/ros2_socketcan/src/socket_can_receiver.cpp
@@ -177,12 +177,12 @@ CanId SocketCanReceiver::receive_fd(void * const data, const std::chrono::nanose
     throw std::runtime_error{strerror(errno)};
   }
 
-  if (frame.len > CANFD_MAX_DLEN) {
-    throw std::runtime_error{"read: frame length is larger than max allowed CAN FD payload length"};
-  }
-
   if (static_cast<std::size_t>(nbytes) < sizeof(frame.can_id) + sizeof(frame.len)) {
     throw std::runtime_error{"read: corrupted CAN frame"};
+  }
+
+  if (frame.len > CANFD_MAX_DLEN) {
+    throw std::runtime_error{"read: frame length is larger than max allowed CAN FD payload length"};
   }
 
   const auto data_length = static_cast<CanId::LengthT>(frame.len);

--- a/ros2_socketcan/src/socket_can_receiver.cpp
+++ b/ros2_socketcan/src/socket_can_receiver.cpp
@@ -182,7 +182,8 @@ CanId SocketCanReceiver::receive_fd(void * const data, const std::chrono::nanose
   }
 
   const auto data_length = static_cast<CanId::LengthT>(frame.len);
-  const auto expected_length = sizeof(frame) - sizeof(frame.data) + data_length; // some CAN FD frames are shorter than 64 bytes
+  // some CAN FD frames are shorter than 64 bytes
+  const auto expected_length = sizeof(frame) - sizeof(frame.data) + data_length;
 
   if (static_cast<std::size_t>(nbytes) < expected_length) {
     throw std::runtime_error{"read: incomplete CAN FD frame"};


### PR DESCRIPTION
From @knzo25 's branch in https://github.com/knzo25/ros2_socketcan/commits/feat/continental_fd/

Related PR:
- https://github.com/autowarefoundation/autoware/pull/5008

### Summary

This PR fixes an issue in the `SocketCanReceiver` class where it incorrectly assumed that all CAN FD frames would be the maximum size (64 bytes). This assumption caused errors when handling shorter frames, as observed with SRR520 frames.

The fix ensures that the `receive_fd` method can properly handle variable-length CAN FD frames by dynamically calculating the expected frame size based on the actual data length (`frame.len`). It also introduces additional safety checks to prevent corrupted or incomplete frames from being processed.

### Changes

- Adjusted the logic in `receive_fd` to handle CAN FD frames shorter than 64 bytes.
- Added a calculation for `expected_length` based on the fixed header size and the variable data length.
- Improved error handling to ensure that corrupted or incomplete frames are rejected.

### Additional Improvements

- Added a check to ensure that the frame length (`frame.len`) does not exceed the CAN FD maximum allowed data length (64 bytes).
- Refactored the error handling to provide more detailed messages in cases of failure.