### PR TITLE
refactor: make the namespace in receiver launch script a parameter

### DIFF
--- a/ros2_socketcan/launch/socket_can_receiver.launch.py
+++ b/ros2_socketcan/launch/socket_can_receiver.launch.py
@@ -21,7 +21,7 @@ from launch.actions import (DeclareLaunchArgument, EmitEvent,
 from launch.conditions import IfCondition, UnlessCondition
 from launch.event_handlers import OnProcessStart
 from launch.events import matches_action
-from launch.substitutions import LaunchConfiguration, TextSubstitution
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LifecycleNode
 from launch_ros.event_handlers import OnStateTransition
 from launch_ros.events.lifecycle import ChangeState
@@ -33,7 +33,7 @@ def generate_launch_description():
         package='ros2_socketcan',
         executable='socket_can_receiver_node_exe',
         name='socket_can_receiver',
-        namespace=TextSubstitution(text=''),
+        namespace=LaunchConfiguration('namespace'),
         parameters=[{
             'interface': LaunchConfiguration('interface'),
             'enable_can_fd': LaunchConfiguration('enable_can_fd'),
@@ -79,6 +79,9 @@ def generate_launch_description():
     )
 
     return LaunchDescription([
+        DeclareLaunchArgument('namespace', default_value='',
+                              description='Namespace for the receiver node. Useful when '
+                                          'launching multiple receivers in one launch file.'),
         DeclareLaunchArgument('interface', default_value='can0'),
         DeclareLaunchArgument('enable_can_fd', default_value='false'),
         DeclareLaunchArgument('interval_sec', default_value='0.01'),


### PR DESCRIPTION
Need to start 2 Can Receiver (2x PCAN) in one launch script and wanted to keep the supplied receiver launch file.
```bash
<launch>

  <arg name="receiver_interval_sec" default="5.0" />
  <arg name="enable_can_fd" default="false" />
  <arg name="use_bus_time" default="false" />
  <arg name="channel_0_name" default="can0_msg" />
  <arg name="channel_1_name" default="can1_msg" />

  <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py">
    <arg name="namespace" value="can0" />
    <arg name="interface" value="can0" />
    <arg name="interval_sec" value="$(var receiver_interval_sec)" />
    <arg name="enable_can_fd" value="$(var enable_can_fd)" />
    <arg name="from_can_bus_topic" value="$(var channel_0_name)" />
    <arg name="use_bus_time" value="$(var use_bus_time)" />
  </include>

  <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py">
    <arg name="namespace" value="can1" />
    <arg name="interface" value="can1" />
    <arg name="interval_sec" value="$(var receiver_interval_sec)" />
    <arg name="enable_can_fd" value="$(var enable_can_fd)" />
    <arg name="from_can_bus_topic" value="$(var channel_1_name)" />
    <arg name="use_bus_time" value="$(var use_bus_time)" />
  </include>

</launch>
```

They ended up with the same name in the same namespace. My solution is to move them in different namespace, and I did that by modifying the receiver launch file to accept the namespace as parameter from the parant launch file. Not sure if it is the ros way. If there is a better way please discard the pull request.  