### PR TITLE
feat: add new ros param to disable warning when no data is received

### DIFF
--- a/ros2_socketcan/include/ros2_socketcan/socket_can_receiver_node.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_receiver_node.hpp
@@ -81,6 +81,7 @@ private:
   std::chrono::nanoseconds interval_ns_;
   bool enable_fd_;
   bool use_bus_time_;
+  bool disable_warn_no_receive_;
 };
 }  // namespace socketcan
 }  // namespace drivers

--- a/ros2_socketcan/include/ros2_socketcan/socket_can_receiver_node.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_receiver_node.hpp
@@ -91,7 +91,7 @@ private:
   std::chrono::nanoseconds interval_ns_;
   bool enable_fd_;
   bool use_bus_time_;
-  bool disable_warn_no_receive_;
+  bool warn_on_receive_timeout_;
 };
 }  // namespace socketcan
 }  // namespace drivers

--- a/ros2_socketcan/launch/socket_can_bridge.launch.xml
+++ b/ros2_socketcan/launch/socket_can_bridge.launch.xml
@@ -9,6 +9,7 @@
   <arg name="to_can_bus_topic" default="to_can_bus" />
   <arg name="filters" default="0:0" />
   <arg name="use_bus_time" default="false" />
+  <arg name="warn_on_receive_timeout" default="true" />
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py">
     <arg name="interface" value="$(var interface)" />
@@ -17,6 +18,7 @@
     <arg name="from_can_bus_topic" value="$(var from_can_bus_topic)" />
     <arg name="filters" value="$(var filters)" />
     <arg name="use_bus_time" value="$(var use_bus_time)" />
+    <arg name="warn_on_receive_timeout" value="$(var warn_on_receive_timeout)" />
   </include>
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_sender.launch.py">

--- a/ros2_socketcan/launch/socket_can_receiver.launch.py
+++ b/ros2_socketcan/launch/socket_can_receiver.launch.py
@@ -41,6 +41,7 @@ def generate_launch_description():
             LaunchConfiguration('interval_sec'),
             'filters': LaunchConfiguration('filters'),
             'use_bus_time': LaunchConfiguration('use_bus_time'),
+            'warn_on_receive_timeout': LaunchConfiguration('warn_on_receive_timeout'),
         }],
         remappings=[('from_can_bus', LaunchConfiguration('from_can_bus_topic')),
                     ('from_can_bus_fd', LaunchConfiguration('from_can_bus_topic'))],
@@ -83,6 +84,11 @@ def generate_launch_description():
         DeclareLaunchArgument('enable_can_fd', default_value='false'),
         DeclareLaunchArgument('interval_sec', default_value='0.01'),
         DeclareLaunchArgument('use_bus_time', default_value='false'),
+        DeclareLaunchArgument('warn_on_receive_timeout', default_value='true',
+                              description='Warn when no CAN frame arrives within '
+                                          'interval_sec. Set to false on a bus that is '
+                                          'idle by design. Real receive errors are '
+                                          'always logged, whatever this value is.'),
         DeclareLaunchArgument('filters', default_value='0:0',
                               description='Comma separated filters can be specified for each given'
                                           ' CAN interface.\n'

--- a/ros2_socketcan/src/socket_can_receiver_node.cpp
+++ b/ros2_socketcan/src/socket_can_receiver_node.cpp
@@ -54,7 +54,7 @@ SocketCanReceiverNode::SocketCanReceiverNode(rclcpp::NodeOptions options)
   interface_ = this->declare_parameter("interface", "can0");
   use_bus_time_ = this->declare_parameter<bool>("use_bus_time", false);
   enable_fd_ = this->declare_parameter<bool>("enable_can_fd", false);
-  disable_warn_no_receive_ = this->declare_parameter<bool>("disable_warn_no_receive", false);
+  warn_on_receive_timeout_ = this->declare_parameter<bool>("warn_on_receive_timeout", true);
   double interval_sec = this->declare_parameter("interval_sec", 0.01);
   this->declare_parameter("filters", "0:0");
   interval_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -192,7 +192,7 @@ void SocketCanReceiverNode::receive()
       try {
         receive_id = receiver_->receive(frame_msg.data.data(), interval_ns_);
       } catch (const SocketCanTimeout &) {
-        if (!disable_warn_no_receive_) {
+        if (warn_on_receive_timeout_) {
           RCLCPP_WARN_THROTTLE(
             this->get_logger(), *this->get_clock(), 1000,
             "No CAN frame received on %s within %.3f s",
@@ -236,7 +236,7 @@ void SocketCanReceiverNode::receive()
       try {
         receive_id = receiver_->receive_fd(fd_frame_msg.data.data<void>(), interval_ns_);
       } catch (const SocketCanTimeout &) {
-        if (!disable_warn_no_receive_) {
+        if (warn_on_receive_timeout_) {
           RCLCPP_WARN_THROTTLE(
             this->get_logger(), *this->get_clock(), 1000,
             "No CAN FD frame received on %s within %.3f s",

--- a/ros2_socketcan/src/socket_can_receiver_node.cpp
+++ b/ros2_socketcan/src/socket_can_receiver_node.cpp
@@ -191,13 +191,19 @@ void SocketCanReceiverNode::receive()
 
       try {
         receive_id = receiver_->receive(frame_msg.data.data(), interval_ns_);
-      } catch (const std::exception & ex) {
+      } catch (const SocketCanTimeout &) {
         if (!disable_warn_no_receive_) {
           RCLCPP_WARN_THROTTLE(
             this->get_logger(), *this->get_clock(), 1000,
-            "Error receiving CAN message: %s - %s",
-            interface_.c_str(), ex.what());
+            "No CAN frame received on %s within %.3f s",
+            interface_.c_str(), std::chrono::duration<double>(interval_ns_).count());
         }
+        continue;
+      } catch (const std::exception & ex) {
+        RCLCPP_WARN_THROTTLE(
+          this->get_logger(), *this->get_clock(), 1000,
+          "Error receiving CAN message: %s - %s",
+          interface_.c_str(), ex.what());
         continue;
       }
 
@@ -229,13 +235,19 @@ void SocketCanReceiverNode::receive()
 
       try {
         receive_id = receiver_->receive_fd(fd_frame_msg.data.data<void>(), interval_ns_);
-      } catch (const std::exception & ex) {
+      } catch (const SocketCanTimeout &) {
         if (!disable_warn_no_receive_) {
           RCLCPP_WARN_THROTTLE(
             this->get_logger(), *this->get_clock(), 1000,
-            "Error receiving CAN FD message: %s - %s",
-            interface_.c_str(), ex.what());
+            "No CAN FD frame received on %s within %.3f s",
+            interface_.c_str(), std::chrono::duration<double>(interval_ns_).count());
         }
+        continue;
+      } catch (const std::exception & ex) {
+        RCLCPP_WARN_THROTTLE(
+          this->get_logger(), *this->get_clock(), 1000,
+          "Error receiving CAN FD message: %s - %s",
+          interface_.c_str(), ex.what());
         continue;
       }
 

--- a/ros2_socketcan/src/socket_can_receiver_node.cpp
+++ b/ros2_socketcan/src/socket_can_receiver_node.cpp
@@ -166,7 +166,7 @@ void SocketCanReceiverNode::receive()
             this->get_logger(), *this->get_clock(), 1000,
             "Error receiving CAN message: %s - %s",
             interface_.c_str(), ex.what());
-          }
+        }
         continue;
       }
 
@@ -202,9 +202,9 @@ void SocketCanReceiverNode::receive()
         if (!disable_warn_no_receive_) {
           RCLCPP_WARN_THROTTLE(
             this->get_logger(), *this->get_clock(), 1000,
-            "Error receiving CAN message: %s - %s",
+            "Error receiving CAN FD message: %s - %s",
             interface_.c_str(), ex.what());
-          }
+        }
         continue;
       }
 

--- a/ros2_socketcan/src/socket_can_receiver_node.cpp
+++ b/ros2_socketcan/src/socket_can_receiver_node.cpp
@@ -42,6 +42,7 @@ SocketCanReceiverNode::SocketCanReceiverNode(rclcpp::NodeOptions options)
   interface_ = this->declare_parameter("interface", "can0");
   use_bus_time_ = this->declare_parameter<bool>("use_bus_time", false);
   enable_fd_ = this->declare_parameter<bool>("enable_can_fd", false);
+  disable_warn_no_receive_ = this->declare_parameter<bool>("disable_warn_no_receive", false);
   double interval_sec = this->declare_parameter("interval_sec", 0.01);
   this->declare_parameter("filters", "0:0");
   interval_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -160,10 +161,12 @@ void SocketCanReceiverNode::receive()
       try {
         receive_id = receiver_->receive(frame_msg.data.data(), interval_ns_);
       } catch (const std::exception & ex) {
-        RCLCPP_WARN_THROTTLE(
-          this->get_logger(), *this->get_clock(), 1000,
-          "Error receiving CAN message: %s - %s",
-          interface_.c_str(), ex.what());
+        if (!disable_warn_no_receive_) {
+          RCLCPP_WARN_THROTTLE(
+            this->get_logger(), *this->get_clock(), 1000,
+            "Error receiving CAN message: %s - %s",
+            interface_.c_str(), ex.what());
+          }
         continue;
       }
 
@@ -196,10 +199,12 @@ void SocketCanReceiverNode::receive()
       try {
         receive_id = receiver_->receive_fd(fd_frame_msg.data.data<void>(), interval_ns_);
       } catch (const std::exception & ex) {
-        RCLCPP_WARN_THROTTLE(
-          this->get_logger(), *this->get_clock(), 1000,
-          "Error receiving CAN FD message: %s - %s",
-          interface_.c_str(), ex.what());
+        if (!disable_warn_no_receive_) {
+          RCLCPP_WARN_THROTTLE(
+            this->get_logger(), *this->get_clock(), 1000,
+            "Error receiving CAN message: %s - %s",
+            interface_.c_str(), ex.what());
+          }
         continue;
       }
 

--- a/ros2_socketcan/src/socket_can_receiver_node.cpp
+++ b/ros2_socketcan/src/socket_can_receiver_node.cpp
@@ -64,6 +64,9 @@ SocketCanReceiverNode::SocketCanReceiverNode(rclcpp::NodeOptions options)
   RCLCPP_INFO(this->get_logger(), "use bus time: %d", use_bus_time_);
   RCLCPP_INFO(this->get_logger(), "can fd enabled: %s", enable_fd_ ? "true" : "false");
   RCLCPP_INFO(this->get_logger(), "interval(s): %f", interval_sec);
+  RCLCPP_INFO(
+    this->get_logger(), "warn on receive timeout: %s",
+    warn_on_receive_timeout_ ? "true" : "false");
 }
 
 SocketCanReceiverNode::~SocketCanReceiverNode()


### PR DESCRIPTION
We get this warning often but it isn't an issue.  It also doesn't make sense to reduce  interval time since we want to receive as fast as possible.  Therefore, a way to disable the warning was added.  