### PR TITLE
add combined sender+receiver class with single socket

### DIFF
--- a/ros2_socketcan/CMakeLists.txt
+++ b/ros2_socketcan/CMakeLists.txt
@@ -18,7 +18,8 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/socket_can_common.cpp
   src/socket_can_id.cpp
   src/socket_can_receiver.cpp
-  src/socket_can_sender.cpp)
+  src/socket_can_sender.cpp
+  src/socket_can_transceiver.cpp)
 
 ament_auto_add_library(socket_can_receiver_node SHARED
   src/socket_can_receiver_node.cpp

--- a/ros2_socketcan/include/ros2_socketcan/socket_can_transceiver.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_transceiver.hpp
@@ -1,0 +1,59 @@
+#ifndef ROS2_SOCKETCAN__SOCKET_CAN_TRANSCEIVER_HPP_
+#define ROS2_SOCKETCAN__SOCKET_CAN_TRANSCEIVER_HPP_
+
+#include "ros2_socketcan/socket_can_id.hpp"
+#include "ros2_socketcan/visibility_control.hpp"
+#include <chrono>
+
+namespace drivers {
+namespace socketcan {
+
+class SOCKETCAN_PUBLIC SocketCanTransceiver {
+public:
+  /// Constructor
+  explicit SocketCanTransceiver(const std::string &interface = "can0");
+  /// Destructor
+  ~SocketCanTransceiver() noexcept;
+
+  /// Send raw data with an explicit CAN id
+  /// \param[in] data A pointer to the beginning of the data to send
+  /// \param[in] timeout Maximum duration to wait for file descriptor to be free
+  /// for write. Negative
+  ///                    durations are treated the same as zero timeout
+  /// \param[in] id The id field for the CAN frame
+  /// \param[in] length The amount of data to send starting from the data
+  /// pointer
+  /// \throw std::domain_error If length is > 8
+  /// \throw SocketCanTimeout On timeout
+  /// \throw std::runtime_error on other errors
+  void send(const void *const data, const std::size_t length, const CanId id,
+            const std::chrono::nanoseconds timeout =
+                std::chrono::nanoseconds::zero()) const;
+
+  /// Receive CAN data
+  /// \param[out] data A buffer to be written with data bytes. Must be at least
+  /// 8 bytes in size
+  /// \param[in] timeout Maximum duration to wait for data on the file
+  /// descriptor. Negative
+  ///                    durations are treated the same as zero timeout
+  /// \return The CanId for the received can_frame, with length appropriately
+  /// populated
+  /// \throw SocketCanTimeout On timeout
+  /// \throw std::runtime_error on other errors
+  CanId receive(void *const data, const std::chrono::nanoseconds timeout =
+                                      std::chrono::nanoseconds::zero()) const;
+
+private:
+  int32_t m_file_descriptor;
+
+  void send_impl(const void *const data, const std::size_t length,
+                 const CanId id, const std::chrono::nanoseconds timeout) const;
+  // Wait for file descriptor to be available to send data via select()
+  SOCKETCAN_LOCAL void wait_send(const std::chrono::nanoseconds timeout) const;
+  SOCKETCAN_LOCAL void
+  wait_receive(const std::chrono::nanoseconds timeout) const;
+};
+} // namespace socketcan
+} // namespace drivers
+
+#endif

--- a/ros2_socketcan/src/socket_can_transceiver.cpp
+++ b/ros2_socketcan/src/socket_can_transceiver.cpp
@@ -1,0 +1,114 @@
+#include "ros2_socketcan/socket_can_transceiver.hpp"
+#include "ros2_socketcan/socket_can_common.hpp"
+#include <cstring>
+#include <linux/sockios.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace drivers {
+namespace socketcan {
+
+SocketCanTransceiver::SocketCanTransceiver(const std::string &interface)
+    : m_file_descriptor{bind_can_socket(interface, false, true)} {}
+
+void SocketCanTransceiver::send(const void *const data,
+                                const std::size_t length, const CanId id,
+                                const std::chrono::nanoseconds timeout) const {
+  if (length > MAX_DATA_LENGTH) {
+    throw std::domain_error{"Size is too large to send via CAN"};
+  }
+  send_impl(data, length, id, timeout);
+}
+
+SocketCanTransceiver::~SocketCanTransceiver() noexcept {
+  // Can't do anything on error; in fact generally shouldn't on close() error
+  (void)close(m_file_descriptor);
+}
+
+void SocketCanTransceiver::send_impl(
+    const void *const data, const std::size_t length, const CanId id,
+    const std::chrono::nanoseconds timeout) const {
+
+  // Use select call on positive timeout
+  wait_send(timeout);
+  // Actually send the data
+  constexpr int flags = 0; // TODO(c.ho) not implemented
+  struct can_frame data_frame;
+  data_frame.can_id = id.get();
+  // User facing functions do check
+  data_frame.can_dlc = static_cast<decltype(data_frame.can_dlc)>(length);
+  // lint -e{586} NOLINT data_frame is a stack variable; guaranteed not to
+  // overlap
+  (void)std::memcpy(static_cast<void *>(&data_frame.data[0U]), data, length);
+  const auto bytes_sent =
+      ::send(m_file_descriptor, &data_frame, sizeof(data_frame), flags);
+  if (0 > bytes_sent) {
+    throw std::runtime_error{strerror(errno)};
+  }
+}
+
+void SocketCanTransceiver::wait_send(
+    const std::chrono::nanoseconds timeout) const {
+  if (decltype(timeout)::zero() < timeout) {
+    auto c_timeout = to_timeval(timeout);
+    auto write_set = single_set(m_file_descriptor);
+    // Wait
+    if (0 ==
+        select(m_file_descriptor + 1, NULL, &write_set, NULL, &c_timeout)) {
+      throw SocketCanTimeout{"CAN Send Timeout"};
+    }
+    // lint --e{9130, 9123, 9125, 1924, 9126} NOLINT
+    if (!FD_ISSET(m_file_descriptor, &write_set)) {
+      throw SocketCanTimeout{"CAN Send timeout"};
+    }
+  }
+}
+
+CanId SocketCanTransceiver::receive(
+    void *const data, const std::chrono::nanoseconds timeout) const {
+
+  wait_receive(timeout);
+  // Read
+  struct can_frame frame;
+  const auto nbytes = read(m_file_descriptor, &frame, sizeof(frame));
+  // Checks
+  if (nbytes < 0) {
+    throw std::runtime_error{strerror(errno)};
+  }
+  if (static_cast<std::size_t>(nbytes) < sizeof(frame)) {
+    throw std::runtime_error{"read: incomplete CAN frame"};
+  }
+  if (static_cast<std::size_t>(nbytes) != sizeof(frame)) {
+    throw std::logic_error{"Message was wrong size"};
+  }
+  // Write
+  const auto data_length = static_cast<CanId::LengthT>(frame.can_dlc);
+  (void)std::memcpy(data, static_cast<void *>(&frame.data[0U]), data_length);
+
+  // get bus timestamp
+  struct timeval tv;
+  ioctl(m_file_descriptor, SIOCGSTAMP, &tv);
+  uint64_t bus_time = from_timeval(tv);
+
+  return CanId{frame.can_id, bus_time, data_length};
+}
+
+void SocketCanTransceiver::wait_receive(
+    const std::chrono::nanoseconds timeout) const {
+  if (decltype(timeout)::zero() < timeout) {
+    auto c_timeout = to_timeval(timeout);
+    auto read_set = single_set(m_file_descriptor);
+    // Wait
+    if (0 == select(m_file_descriptor + 1, &read_set, NULL, NULL, &c_timeout)) {
+      throw SocketCanTimeout{"CAN Receive Timeout"};
+    }
+    // lint --e{9130, 1924, 9123, 9125, 1924, 9126} NOLINT
+    if (!FD_ISSET(m_file_descriptor, &read_set)) {
+      throw SocketCanTimeout{"CAN Receive timeout"};
+    }
+  }
+}
+
+} // namespace socketcan
+} // namespace drivers


### PR DESCRIPTION
Hi! I find the socketcan wrapper classes very useful, the design of seperate receiver and sender however has one limitation: Since each has its own socket, it becomes difficult to ignore messages sent by the same ros node. #45 disables loopback by default, but that stops the use-case of running the same node twice and have it communicate (for testing purposes) via a (v)can interface.

Attached is an implementation to try it out, and it works as expected: The transceiver does not receive messages it has sent, but another instance of the same ros node receives its messages.

I wanted to ask if something like this would be considered for inclusion, before looking at implementing it properly (it's just the bare minimum sender and receiver copy-pasted together right now). I would imagine at least moving some implementation details to socket_can_common, or maybe it would be possible to just derive the Transceiver class from Sender and Receiver.

See also the linux kernel docs for [CAN_RAW_LOOPBACK](https://docs.kernel.org/networking/can.html#raw-socket-option-can-raw-loopback) and [CAN_RAW_RECV_OWN_MSGS](https://docs.kernel.org/networking/can.html#raw-socket-option-can-raw-recv-own-msgs).