### PR TITLE
fix: refactor ament_auto_package usage in CMakeLists.txt

### DIFF
--- a/ros2_socketcan/CMakeLists.txt
+++ b/ros2_socketcan/CMakeLists.txt
@@ -59,6 +59,8 @@ if(BUILD_TESTING)
   target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME})
 endif()
 
-ament_auto_package(INSTALL_TO_SHARE
-  launch
+ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+  INSTALL_TO_SHARE
+    launch
 )


### PR DESCRIPTION
Fixes colcon build warning
Building the package on ros2 jazzy currently prints the following warning:
```shell
--- stderr: ros2_socketcan                                
In this package, headers install destination is set to `include` by ament_auto_package. It is recommended to install `include/ros2_socketcan` instead and will be the default behavior of ament_auto_package from ROS 2 Kilted Kaiju. On distributions before Kilted, ament_auto_package behaves the same way when you use USE_SCOPED_HEADER_INSTALL_DIR option.
---
```
