### PR TITLE
feat: fix virtual CAN message reading by disabling filters by default and adding loopback to sender

### DIFF
--- a/ros2_socketcan/include/ros2_socketcan/socket_can_sender.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_sender.hpp
@@ -38,6 +38,7 @@ public:
   explicit SocketCanSender(
     const std::string & interface = "can0",
     const bool enable_fd = false,
+    const bool enable_loopback = false,
     const CanId & default_id = CanId{});
   /// Destructor
   ~SocketCanSender() noexcept;

--- a/ros2_socketcan/include/ros2_socketcan/socket_can_sender_node.hpp
+++ b/ros2_socketcan/include/ros2_socketcan/socket_can_sender_node.hpp
@@ -76,6 +76,7 @@ public:
 private:
   std::string interface_;
   bool enable_fd_;
+  bool enable_loopback_;
   rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr frames_sub_;
   rclcpp::Subscription<ros2_socketcan_msgs::msg::FdFrame>::SharedPtr fd_frames_sub_;
   std::unique_ptr<SocketCanSender> sender_;

--- a/ros2_socketcan/launch/socket_can_bridge.launch.xml
+++ b/ros2_socketcan/launch/socket_can_bridge.launch.xml
@@ -7,7 +7,7 @@
   <arg name="enable_frame_loopback" default="false" />
   <arg name="from_can_bus_topic" default="from_can_bus" />
   <arg name="to_can_bus_topic" default="to_can_bus" />
-  <arg name="filters" default="0:0" />
+  <arg name="filters" default="" />
   <arg name="use_bus_time" default="false" />
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py">
@@ -24,6 +24,7 @@
     <arg name="interface" value="$(var interface)" />
     <arg name="timeout_sec" value="$(var sender_timeout_sec)" />
     <arg name="enable_can_fd" value="$(var enable_can_fd)" />
+    <arg name="enable_frame_loopback" value="$(var enable_frame_loopback)" />
     <arg name="to_can_bus_topic" value="$(var to_can_bus_topic)" />
   </include>
 

--- a/ros2_socketcan/launch/socket_can_receiver.launch.py
+++ b/ros2_socketcan/launch/socket_can_receiver.launch.py
@@ -85,7 +85,7 @@ def generate_launch_description():
         DeclareLaunchArgument('enable_frame_loopback', default_value='false'),
         DeclareLaunchArgument('interval_sec', default_value='0.01'),
         DeclareLaunchArgument('use_bus_time', default_value='false'),
-        DeclareLaunchArgument('filters', default_value='0:0',
+        DeclareLaunchArgument('filters', default_value='',
                               description='Comma separated filters can be specified for each given'
                                           ' CAN interface.\n'
                                           '\t<can_id>:<can_mask>\n'

--- a/ros2_socketcan/launch/socket_can_sender.launch.py
+++ b/ros2_socketcan/launch/socket_can_sender.launch.py
@@ -37,6 +37,7 @@ def generate_launch_description():
         parameters=[{
             'interface': LaunchConfiguration('interface'),
             'enable_can_fd': LaunchConfiguration('enable_can_fd'),
+            'enable_frame_loopback': LaunchConfiguration('enable_frame_loopback'),
             'timeout_sec':
             LaunchConfiguration('timeout_sec'),
         }],
@@ -79,6 +80,7 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument('interface', default_value='can0'),
         DeclareLaunchArgument('enable_can_fd', default_value='false'),
+        DeclareLaunchArgument('enable_frame_loopback', default_value='false'),
         DeclareLaunchArgument('timeout_sec', default_value='0.01'),
         DeclareLaunchArgument('auto_configure', default_value='true'),
         DeclareLaunchArgument('auto_activate', default_value='true'),

--- a/ros2_socketcan/src/socket_can_receiver_node.cpp
+++ b/ros2_socketcan/src/socket_can_receiver_node.cpp
@@ -40,7 +40,7 @@ SocketCanReceiverNode::SocketCanReceiverNode(rclcpp::NodeOptions options)
   enable_fd_ = this->declare_parameter<bool>("enable_can_fd", false);
   enable_loopback_ = this->declare_parameter<bool>("enable_frame_loopback", false);
   double interval_sec = this->declare_parameter("interval_sec", 0.01);
-  this->declare_parameter("filters", "0:0");
+  this->declare_parameter("filters", "");
   interval_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
     std::chrono::duration<double>(interval_sec));
 

--- a/ros2_socketcan/src/socket_can_sender.cpp
+++ b/ros2_socketcan/src/socket_can_sender.cpp
@@ -36,9 +36,10 @@ namespace socketcan
 SocketCanSender::SocketCanSender(
   const std::string & interface,
   const bool enable_fd,
+  const bool enable_loopback,
   const CanId & default_id)
 : m_enable_fd(enable_fd),
-  m_file_descriptor{bind_can_socket(interface, m_enable_fd)},
+  m_file_descriptor{bind_can_socket(interface, m_enable_fd, enable_loopback)},
   m_default_id{default_id}
 {
 }

--- a/ros2_socketcan/src/socket_can_sender_node.cpp
+++ b/ros2_socketcan/src/socket_can_sender_node.cpp
@@ -35,12 +35,16 @@ SocketCanSenderNode::SocketCanSenderNode(rclcpp::NodeOptions options)
 {
   interface_ = this->declare_parameter("interface", "can0");
   enable_fd_ = this->declare_parameter("enable_can_fd", false);
+  enable_loopback_ = this->declare_parameter("enable_frame_loopback", false);
   double timeout_sec = this->declare_parameter("timeout_sec", 0.01);
   timeout_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
     std::chrono::duration<double>(timeout_sec));
 
   RCLCPP_INFO(this->get_logger(), "interface: %s", interface_.c_str());
   RCLCPP_INFO(this->get_logger(), "can fd enabled: %s", enable_fd_ ? "true" : "false");
+  RCLCPP_INFO(
+    this->get_logger(), "frame loopback enabled: %s",
+    enable_loopback_ ? "true" : "false");
   RCLCPP_INFO(this->get_logger(), "timeout(s): %f", timeout_sec);
 }
 
@@ -49,7 +53,7 @@ LNI::CallbackReturn SocketCanSenderNode::on_configure(const lc::State & state)
   (void)state;
 
   try {
-    sender_ = std::make_unique<SocketCanSender>(interface_, enable_fd_);
+    sender_ = std::make_unique<SocketCanSender>(interface_, enable_fd_, enable_loopback_);
   } catch (const std::exception & ex) {
     RCLCPP_ERROR(
       this->get_logger(), "Error opening CAN sender: %s - %s",

--- a/ros2_socketcan/test/receiver.cpp
+++ b/ros2_socketcan/test/receiver.cpp
@@ -39,7 +39,7 @@ protected:
   {
     constexpr auto test_interface = "vcan0";
     receiver_ = std::make_unique<SocketCanReceiver>(test_interface);
-    sender_ = std::make_unique<SocketCanSender>(test_interface);
+    sender_ = std::make_unique<SocketCanSender>(test_interface, false, false);
   }
 
   std::unique_ptr<SocketCanReceiver> receiver_{};

--- a/ros2_socketcan/test/sanity_checks.cpp
+++ b/ros2_socketcan/test/sanity_checks.cpp
@@ -120,7 +120,7 @@ protected:
   void SetUp()
   {
     constexpr auto TEST_INTERFACE = "vcan0";
-    sender_ = std::make_unique<SocketCanSender>(TEST_INTERFACE);
+    sender_ = std::make_unique<SocketCanSender>(TEST_INTERFACE, false, false);
     // Set up file descriptor
     file_descriptor_ = socket(PF_CAN, SOCK_RAW, CAN_RAW);
     fcntl(file_descriptor_, F_SETFL, O_NONBLOCK);


### PR DESCRIPTION
- Change default CAN filters from '0:0' to '' to disable filters and accept all messages
- Add enable_frame_loopback parameter to SocketCanSender for virtual CAN compatibility
- Update launch files to pass loopback parameter to both sender and receiver
- Update tests to use new sender constructor