### PR TITLE
Update CI on main for Kilted and Rolling

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,22 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         ros_distribution:
-          - humble
-          - iron
-          - jazzy
+          - kilted
           - rolling
         include:
-          # Humble Hawksbill (May 2022 - May 2027)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
-            ros_distribution: humble
-            ros_version: 2
-          # Iron Irwini (May 2023 - November 2024)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-iron-ros-base-latest
-            ros_distribution: iron
-            ros_version: 2
-          # Jazzy Jalisco (May 2024 - May 2029)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-jazzy-ros-base-latest
-            ros_distribution: jazzy
+          # Kilted Kaiju (May 2025 - December 2026)
+          - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-kilted-ros-base-latest
+            ros_distribution: kilted
             ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
           - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest


### PR DESCRIPTION
`main` targets only the latest release + rolling.