### PR TITLE
feat(`agnocast`): adopt `CallbackIsolatedAgnocastExecutor` (CIE)

### DIFF
--- a/ros2_socketcan/CMakeLists.txt
+++ b/ros2_socketcan/CMakeLists.txt
@@ -12,6 +12,8 @@ endif()
 
 # find dependencies
 find_package(ament_cmake_auto REQUIRED)
+find_package(agnocast_components REQUIRED)
+find_package(agnocastlib REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
@@ -23,14 +25,18 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 ament_auto_add_library(socket_can_receiver_node SHARED
   src/socket_can_receiver_node.cpp
 )
+ament_target_dependencies(socket_can_receiver_node
+  agnocastlib
+)
 
 target_link_libraries(socket_can_receiver_node
   ${PROJECT_NAME}
 )
 
-rclcpp_components_register_node(socket_can_receiver_node
+agnocast_components_register_node(socket_can_receiver_node
   PLUGIN "drivers::socketcan::SocketCanReceiverNode"
   EXECUTABLE socket_can_receiver_node_exe
+  EXECUTOR CallbackIsolatedAgnocastExecutor
 )
 
 ament_auto_add_library(socket_can_sender_node SHARED
@@ -41,9 +47,10 @@ target_link_libraries(socket_can_sender_node
   ${PROJECT_NAME}
 )
 
-rclcpp_components_register_node(socket_can_sender_node
+agnocast_components_register_node(socket_can_sender_node
   PLUGIN "drivers::socketcan::SocketCanSenderNode"
   EXECUTABLE socket_can_sender_node_exe
+  EXECUTOR CallbackIsolatedAgnocastExecutor
 )
 
 if(BUILD_TESTING)

--- a/ros2_socketcan/CMakeLists.txt
+++ b/ros2_socketcan/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 # find dependencies
 find_package(ament_cmake_auto REQUIRED)
 find_package(agnocast_components REQUIRED)
-find_package(cie_thread_configurator) REQUIRED)
+find_package(cie_thread_configurator REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED

--- a/ros2_socketcan/CMakeLists.txt
+++ b/ros2_socketcan/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 # find dependencies
 find_package(ament_cmake_auto REQUIRED)
 find_package(agnocast_components REQUIRED)
-find_package(agnocastlib REQUIRED)
+find_package(cie_thread_configurator) REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
@@ -26,7 +26,7 @@ ament_auto_add_library(socket_can_receiver_node SHARED
   src/socket_can_receiver_node.cpp
 )
 ament_target_dependencies(socket_can_receiver_node
-  agnocastlib
+  cie_thread_configurator
 )
 
 target_link_libraries(socket_can_receiver_node

--- a/ros2_socketcan/CMakeLists.txt
+++ b/ros2_socketcan/CMakeLists.txt
@@ -12,9 +12,20 @@ endif()
 
 # find dependencies
 find_package(ament_cmake_auto REQUIRED)
-find_package(agnocast_components REQUIRED)
-find_package(agnocast_cie_thread_configurator REQUIRED)
 ament_auto_find_build_dependencies()
+
+# if ENABLE_AGNOCAST environment variable is set to 1, enable agnocast components
+# and define a compile definition to conditionally compile code that depends on agnocast
+set(ENABLE_AGNOCAST_VAL "$ENV{ENABLE_AGNOCAST}")
+if(NOT DEFINED ENV{ENABLE_AGNOCAST} OR ENABLE_AGNOCAST_VAL STREQUAL "")
+  set(ENABLE_AGNOCAST_VAL "0")
+endif()
+
+if(ENABLE_AGNOCAST_VAL STREQUAL "1")
+  find_package(agnocast_components REQUIRED)
+  find_package(agnocast_cie_thread_configurator REQUIRED)
+  add_compile_definitions(USE_AGNOCAST_ENABLED)
+endif()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/socket_can_common.cpp
@@ -25,19 +36,29 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 ament_auto_add_library(socket_can_receiver_node SHARED
   src/socket_can_receiver_node.cpp
 )
-ament_target_dependencies(socket_can_receiver_node
-  agnocast_cie_thread_configurator
-)
+
+if(ENABLE_AGNOCAST_VAL STREQUAL "1")
+  ament_target_dependencies(socket_can_receiver_node
+    agnocast_cie_thread_configurator
+  )
+endif()
 
 target_link_libraries(socket_can_receiver_node
   ${PROJECT_NAME}
 )
 
-agnocast_components_register_node(socket_can_receiver_node
-  PLUGIN "drivers::socketcan::SocketCanReceiverNode"
-  EXECUTABLE socket_can_receiver_node_exe
-  EXECUTOR CallbackIsolatedAgnocastExecutor
-)
+if(ENABLE_AGNOCAST_VAL STREQUAL "1")
+  agnocast_components_register_node(socket_can_receiver_node
+    PLUGIN "drivers::socketcan::SocketCanReceiverNode"
+    EXECUTABLE socket_can_receiver_node_exe
+    EXECUTOR CallbackIsolatedAgnocastExecutor
+  )
+else()
+  rclcpp_components_register_node(socket_can_receiver_node
+    PLUGIN "drivers::socketcan::SocketCanReceiverNode"
+    EXECUTABLE socket_can_receiver_node_exe
+  )
+endif()
 
 ament_auto_add_library(socket_can_sender_node SHARED
   src/socket_can_sender_node.cpp
@@ -47,11 +68,18 @@ target_link_libraries(socket_can_sender_node
   ${PROJECT_NAME}
 )
 
-agnocast_components_register_node(socket_can_sender_node
-  PLUGIN "drivers::socketcan::SocketCanSenderNode"
-  EXECUTABLE socket_can_sender_node_exe
-  EXECUTOR CallbackIsolatedAgnocastExecutor
-)
+if(ENABLE_AGNOCAST_VAL STREQUAL "1")
+  agnocast_components_register_node(socket_can_sender_node
+    PLUGIN "drivers::socketcan::SocketCanSenderNode"
+    EXECUTABLE socket_can_sender_node_exe
+    EXECUTOR CallbackIsolatedAgnocastExecutor
+  )
+else()
+  rclcpp_components_register_node(socket_can_sender_node
+    PLUGIN "drivers::socketcan::SocketCanSenderNode"
+    EXECUTABLE socket_can_sender_node_exe
+  )
+endif()
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/ros2_socketcan/CMakeLists.txt
+++ b/ros2_socketcan/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 # find dependencies
 find_package(ament_cmake_auto REQUIRED)
 find_package(agnocast_components REQUIRED)
-find_package(cie_thread_configurator REQUIRED)
+find_package(agnocast_cie_thread_configurator REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
@@ -26,7 +26,7 @@ ament_auto_add_library(socket_can_receiver_node SHARED
   src/socket_can_receiver_node.cpp
 )
 ament_target_dependencies(socket_can_receiver_node
-  cie_thread_configurator
+  agnocast_cie_thread_configurator
 )
 
 target_link_libraries(socket_can_receiver_node

--- a/ros2_socketcan/CMakeLists.txt
+++ b/ros2_socketcan/CMakeLists.txt
@@ -29,7 +29,6 @@ option(ENABLE_AGNOCAST "Enable Agnocast components" ${ENABLE_AGNOCAST_DEFAULT})
 if(ENABLE_AGNOCAST)
   find_package(agnocast_components REQUIRED)
   find_package(agnocast_cie_thread_configurator REQUIRED)
-  add_compile_definitions(USE_AGNOCAST_ENABLED)
 endif()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
@@ -43,6 +42,7 @@ ament_auto_add_library(socket_can_receiver_node SHARED
 )
 
 if(ENABLE_AGNOCAST)
+  target_compile_definitions(socket_can_receiver_node PRIVATE USE_AGNOCAST_ENABLED)
   ament_target_dependencies(socket_can_receiver_node
     agnocast_cie_thread_configurator
   )

--- a/ros2_socketcan/CMakeLists.txt
+++ b/ros2_socketcan/CMakeLists.txt
@@ -16,12 +16,17 @@ ament_auto_find_build_dependencies()
 
 # if ENABLE_AGNOCAST environment variable is set to 1, enable agnocast components
 # and define a compile definition to conditionally compile code that depends on agnocast
-set(ENABLE_AGNOCAST_VAL "$ENV{ENABLE_AGNOCAST}")
-if(NOT DEFINED ENV{ENABLE_AGNOCAST} OR ENABLE_AGNOCAST_VAL STREQUAL "")
-  set(ENABLE_AGNOCAST_VAL "0")
+set(ENABLE_AGNOCAST_DEFAULT "$ENV{ENABLE_AGNOCAST}")
+if(ENABLE_AGNOCAST_DEFAULT STREQUAL "1")
+  set(ENABLE_AGNOCAST_DEFAULT "ON")
+else()
+  # default to OFF when the environment variable is unset or not equal to "1"
+  set(ENABLE_AGNOCAST_DEFAULT "OFF")
 endif()
 
-if(ENABLE_AGNOCAST_VAL STREQUAL "1")
+option(ENABLE_AGNOCAST "Enable Agnocast components" ${ENABLE_AGNOCAST_DEFAULT})
+
+if(ENABLE_AGNOCAST)
   find_package(agnocast_components REQUIRED)
   find_package(agnocast_cie_thread_configurator REQUIRED)
   add_compile_definitions(USE_AGNOCAST_ENABLED)
@@ -37,7 +42,7 @@ ament_auto_add_library(socket_can_receiver_node SHARED
   src/socket_can_receiver_node.cpp
 )
 
-if(ENABLE_AGNOCAST_VAL STREQUAL "1")
+if(ENABLE_AGNOCAST)
   ament_target_dependencies(socket_can_receiver_node
     agnocast_cie_thread_configurator
   )
@@ -47,7 +52,7 @@ target_link_libraries(socket_can_receiver_node
   ${PROJECT_NAME}
 )
 
-if(ENABLE_AGNOCAST_VAL STREQUAL "1")
+if(ENABLE_AGNOCAST)
   agnocast_components_register_node(socket_can_receiver_node
     PLUGIN "drivers::socketcan::SocketCanReceiverNode"
     EXECUTABLE socket_can_receiver_node_exe
@@ -68,7 +73,7 @@ target_link_libraries(socket_can_sender_node
   ${PROJECT_NAME}
 )
 
-if(ENABLE_AGNOCAST_VAL STREQUAL "1")
+if(ENABLE_AGNOCAST)
   agnocast_components_register_node(socket_can_sender_node
     PLUGIN "drivers::socketcan::SocketCanSenderNode"
     EXECUTABLE socket_can_sender_node_exe

--- a/ros2_socketcan/launch/socket_can_bridge.launch.xml
+++ b/ros2_socketcan/launch/socket_can_bridge.launch.xml
@@ -1,6 +1,6 @@
 <launch>
 
-  <arg name="interface" default="vcan02" />
+  <arg name="interface" default="can0" />
   <arg name="receiver_interval_sec" default="0.01" />
   <arg name="sender_timeout_sec" default="0.01" />
   <arg name="enable_can_fd" default="false" />

--- a/ros2_socketcan/launch/socket_can_bridge.launch.xml
+++ b/ros2_socketcan/launch/socket_can_bridge.launch.xml
@@ -1,6 +1,6 @@
 <launch>
 
-  <arg name="interface" default="can0" />
+  <arg name="interface" default="vcan02" />
   <arg name="receiver_interval_sec" default="0.01" />
   <arg name="sender_timeout_sec" default="0.01" />
   <arg name="enable_can_fd" default="false" />

--- a/ros2_socketcan/package.xml
+++ b/ros2_socketcan/package.xml
@@ -9,8 +9,8 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>agnocatlib</depend>
   <depend>agnocast_components</depend>
+  <depend>cie_thread_configurator</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rclcpp_lifecycle</depend>

--- a/ros2_socketcan/package.xml
+++ b/ros2_socketcan/package.xml
@@ -9,6 +9,8 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>agnocatlib</depend>
+  <depend>agnocast_components</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rclcpp_lifecycle</depend>

--- a/ros2_socketcan/package.xml
+++ b/ros2_socketcan/package.xml
@@ -9,8 +9,8 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>agnocast_cie_thread_configurator</depend>
   <depend>agnocast_components</depend>
-  <depend>cie_thread_configurator</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rclcpp_lifecycle</depend>

--- a/ros2_socketcan/package.xml
+++ b/ros2_socketcan/package.xml
@@ -9,8 +9,8 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>agnocast_cie_thread_configurator</depend>
-  <depend>agnocast_components</depend>
+  <depend condition="$ENABLE_AGNOCAST == 1">agnocast_cie_thread_configurator</depend>
+  <depend condition="$ENABLE_AGNOCAST == 1">agnocast_components</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rclcpp_lifecycle</depend>

--- a/ros2_socketcan/src/socket_can_receiver_node.cpp
+++ b/ros2_socketcan/src/socket_can_receiver_node.cpp
@@ -17,6 +17,8 @@
 #include "ros2_socketcan/socket_can_receiver_node.hpp"
 #include "ros2_socketcan/socket_can_common.hpp"
 
+#include <cie_thread_configurator/cie_thread_configurator.hpp>
+
 #include <chrono>
 #include <memory>
 #include <string>
@@ -79,7 +81,9 @@ LNI::CallbackReturn SocketCanReceiverNode::on_configure(const lc::State & state)
       this->create_publisher<ros2_socketcan_msgs::msg::FdFrame>("from_can_bus_fd", 500);
   }
 
-  receiver_thread_ = std::make_unique<std::thread>(&SocketCanReceiverNode::receive, this);
+  receiver_thread_ = std::make_unique<std::thread>(
+    cie_thread_configurator::spawn_non_ros2_thread(
+    "socket_can_receiver:receiver_thread", &SocketCanReceiverNode::receive, this));
 
   return LNI::CallbackReturn::SUCCESS;
 }

--- a/ros2_socketcan/src/socket_can_receiver_node.cpp
+++ b/ros2_socketcan/src/socket_can_receiver_node.cpp
@@ -17,7 +17,9 @@
 #include "ros2_socketcan/socket_can_receiver_node.hpp"
 #include "ros2_socketcan/socket_can_common.hpp"
 
+#ifdef USE_AGNOCAST_ENABLED
 #include <agnocast_cie_thread_configurator/cie_thread_configurator.hpp>
+#endif
 
 #include <chrono>
 #include <memory>
@@ -81,9 +83,13 @@ LNI::CallbackReturn SocketCanReceiverNode::on_configure(const lc::State & state)
       this->create_publisher<ros2_socketcan_msgs::msg::FdFrame>("from_can_bus_fd", 500);
   }
 
+#ifdef USE_AGNOCAST_ENABLED
   receiver_thread_ = std::make_unique<std::thread>(
     agnocast_cie_thread_configurator::spawn_non_ros2_thread(
     "socket_can_receiver:receiver_thread", &SocketCanReceiverNode::receive, this));
+#else
+  receiver_thread_ = std::make_unique<std::thread>(&SocketCanReceiverNode::receive, this);
+#endif
 
   return LNI::CallbackReturn::SUCCESS;
 }

--- a/ros2_socketcan/src/socket_can_receiver_node.cpp
+++ b/ros2_socketcan/src/socket_can_receiver_node.cpp
@@ -17,7 +17,7 @@
 #include "ros2_socketcan/socket_can_receiver_node.hpp"
 #include "ros2_socketcan/socket_can_common.hpp"
 
-#include <cie_thread_configurator/cie_thread_configurator.hpp>
+#include <agnocast_cie_thread_configurator/cie_thread_configurator.hpp>
 
 #include <chrono>
 #include <memory>
@@ -82,7 +82,7 @@ LNI::CallbackReturn SocketCanReceiverNode::on_configure(const lc::State & state)
   }
 
   receiver_thread_ = std::make_unique<std::thread>(
-    cie_thread_configurator::spawn_non_ros2_thread(
+    agnocast_cie_thread_configurator::spawn_non_ros2_thread(
     "socket_can_receiver:receiver_thread", &SocketCanReceiverNode::receive, this));
 
   return LNI::CallbackReturn::SUCCESS;

--- a/ros2_socketcan/src/socket_can_receiver_node.cpp
+++ b/ros2_socketcan/src/socket_can_receiver_node.cpp
@@ -84,9 +84,10 @@ LNI::CallbackReturn SocketCanReceiverNode::on_configure(const lc::State & state)
   }
 
 #ifdef USE_AGNOCAST_ENABLED
+  const std::string thread_name = "socket_can_receiver:" + interface_ + ":receiver_thread";
   receiver_thread_ = std::make_unique<std::thread>(
     agnocast_cie_thread_configurator::spawn_non_ros2_thread(
-    "socket_can_receiver:receiver_thread", &SocketCanReceiverNode::receive, this));
+    thread_name.c_str(), &SocketCanReceiverNode::receive, this));
 #else
   receiver_thread_ = std::make_unique<std::thread>(&SocketCanReceiverNode::receive, this);
 #endif


### PR DESCRIPTION
## Description

This PR enables **CallbackIsolatedAgnocastExecutor (CIE)** support for `ros2_socketcan`. Similar to other driver packages, this allows for middleware-transparent scheduling and optimized response times.

The implementation uses the environment variable `ENABLE_AGNOCAST` at **build time** to conditionally switch between the standard ROS 2 stack and the Agnocast-enabled stack. 

### Conditional Build Mechanism
- **If `ENABLE_AGNOCAST=1` during build:**
  - The macro `USE_AGNOCAST_ENABLED` is defined for C++ sources.
  - Nodes are registered using `agnocast_components_register_node` with `CallbackIsolatedAgnocastExecutor`.
  - In `SocketCanReceiverNode`, the receiver thread is spawned via `agnocast_cie_thread_configurator::spawn_non_ros2_thread` to enable thread-level scheduling configuration.
- **If `ENABLE_AGNOCAST` is unset or `0`:**
  - Nodes are registered using the standard `rclcpp_components_register_node`.
  - The receiver thread is spawned as a standard `std::thread`.
  - No dependency on Agnocast libraries is required for the build.

### Changes

- **ros2_socketcan/CMakeLists.txt**: 
  - Added logic to detect `ENABLE_AGNOCAST` and define `USE_AGNOCAST_ENABLED`.
  - Conditionally finds `agnocast_components` and `agnocast_cie_thread_configurator`.
  - Replaced/Branched `rclcpp_components_register_node` with `agnocast_components_register_node` for both `socket_can_receiver_node` and `socket_can_sender_node`.
- **ros2_socketcan/package.xml**: 
  - Added conditional dependencies for Agnocast-related packages using the `condition` attribute.
- **ros2_socketcan/src/socket_can_receiver_node.cpp**: 
  - Integrated `agnocast_cie_thread_configurator` within `on_configure` to wrap the `receiver_thread_` creation when Agnocast is enabled.

## Related links

- [Autoware Discussion about adopting CIE](https://github.com/orgs/autowarefoundation/discussions/6813)

## How was this PR tested?

- **Build test**: Verified successful builds with both `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1`.
- `**execution` test**: Verified that the nodes run with the expected executor in both modes.

## Notes for reviewers

- **Component Registration**: Please verify that `agnocast_components_register_node` is correctly configured to use `CallbackIsolatedAgnocastExecutor`.
- **Thread Management**: In `SocketCanReceiverNode`, the thread is now named dynamically (including the interface name) when Agnocast is enabled. Ensure this naming convention is acceptable.
- **Lifecycle Consistency**: Verified that the Agnocast thread configuration occurs within the `on_configure` lifecycle transition, maintaining consistency with the original design.

## Interface changes

None.

## Effects on system behavior

- **When `ENABLE_AGNOCAST=0` (default)**: Standard ROS 2 behavior. No changes to execution or scheduling.
- **When `ENABLE_AGNOCAST=1`**: Uses `CallbackIsolatedAgnocastExecutor`. The `receiver_thread_` is registered as a managed non-ROS thread, allowing the Agnocast scheduler to optimize its priority and affinity alongside ROS 2 callbacks.