### PR TITLE
ci: fix triggers and matrix for the jazzy branch

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,8 +3,7 @@ name: ROS2 CI
 on:
   pull_request:
     branches:
-      - 'develop'
-      - 'main'
+      - 'jazzy'
 
 jobs:
   test_environment:
@@ -13,26 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         ros_distribution:
-          - humble
-          - iron
           - jazzy
-          - rolling
         include:
-          # Humble Hawksbill (May 2022 - May 2027)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
-            ros_distribution: humble
-            ros_version: 2
-          # Iron Irwini (May 2023 - November 2024)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-iron-ros-base-latest
-            ros_distribution: iron
-            ros_version: 2
           # Jazzy Jalisco (May 2024 - May 2029)
           - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-jazzy-ros-base-latest
             ros_distribution: jazzy
-            ros_version: 2
-          # Rolling Ridley  (June 2020 - Present)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
-            ros_distribution: rolling
             ros_version: 2
     container:
       image: ${{ matrix.docker_image }}


### PR DESCRIPTION
## Description

No build runs on PRs that target the `jazzy` branch. The `pull_request` trigger in `build_test.yml` lists only `develop` and `main`. The `develop` branch does not exist, and PRs to `main` use the `main` copy of this workflow. This PR sets the trigger to `jazzy`.

It also trims the build matrix to Jazzy only, the distro this branch releases to. This follows the `main` branch, which builds only Kilted and Rolling:

- #71

The trigger fix alone would turn this branch red on the first PR it tests. The `iron` job would fail on the pending header install change, because `ament_cmake_auto` on Iron never gained the `USE_SCOPED_HEADER_INSTALL_DIR` option, and Iron is EOL since November 2024. Humble and Rolling have their own branches. The pending PR:

- #68

Because `pull_request` events read the workflow from the merge ref, this PR runs the new jazzy job on itself.

## AI usage

**AI usage:** written with Claude Code during a review session on the header install PR listed above; the session found the CI gap and produced this fix.

**Self-review:** Simple PR, reviewed.

<details>
<summary><strong>Verification:</strong> the workflow parses as YAML locally; the real workflow run happens on this PR itself, because the merge ref carries the new trigger.</summary>

### Local YAML check

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build_test.yml'))"` printed `YAML OK`
- `actionlint` did not run; it is not installed on this machine

### What did not run here

- The GitHub Actions workflow itself. It runs when this PR opens, because the new trigger matches the `jazzy` base branch.
- No colcon build ran for this change; it touches only the workflow file.

</details>
