### PR TITLE
ci: fix triggers and matrix for the humble and jazzy lineage

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -12,8 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         ros_distribution:
+          - humble
           - jazzy
         include:
+          # Humble Hawksbill (May 2022 - May 2027)
+          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
+            ros_distribution: humble
+            ros_version: 2
           # Jazzy Jalisco (May 2024 - May 2029)
           - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-jazzy-ros-base-latest
             ros_distribution: jazzy

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,6 +3,7 @@ name: ROS2 CI
 on:
   pull_request:
     branches:
+      - 'humble'
       - 'jazzy'
 
 jobs:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,8 +3,7 @@ name: ROS2 CI
 on:
   pull_request:
     branches:
-      - 'develop'
-      - 'main'
+      - 'jazzy'
 
 jobs:
   test_environment:
@@ -13,26 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         ros_distribution:
-          - humble
-          - iron
           - jazzy
-          - rolling
         include:
-          # Humble Hawksbill (May 2022 - May 2027)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
-            ros_distribution: humble
-            ros_version: 2
-          # Iron Irwini (May 2023 - November 2024)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-iron-ros-base-latest
-            ros_distribution: iron
-            ros_version: 2
           # Jazzy Jalisco (May 2024 - May 2029)
           - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-jazzy-ros-base-latest
             ros_distribution: jazzy
-            ros_version: 2
-          # Rolling Ridley  (June 2020 - Present)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
-            ros_distribution: rolling
             ros_version: 2
     container:
       image: ${{ matrix.docker_image }}


### PR DESCRIPTION
## Description

No build runs on PRs that target the `jazzy` branch. The `pull_request` trigger in `build_test.yml` lists only `develop` and `main`. The `develop` branch does not exist. PRs to `main` use the `main` copy of this workflow. This PR sets the trigger to `humble` and `jazzy`.

This PR also trims the build matrix to Humble and Jazzy. Rolling belongs to the `main` matrix, which builds only Kilted and Rolling:

- #71

The matrix must not keep `iron`. `ament_cmake_auto` on Iron never gained the `USE_SCOPED_HEADER_INSTALL_DIR` option, and the pending header install change needs that option. Iron also went EOL in November 2024. The pending PR:

- #68

The humble job stays while the `jazzy` and `humble` lineages are content-identical. The job then proves every backport on both distros, and one release line can serve both. When the branches diverge, the humble job moves out.

The `humble` trigger entry is dormant while this file lives on the `jazzy` branch. When the `humble` branch fast-forwards to this lineage, this entry becomes active, and PRs to `humble` get CI without a further edit.

Because `pull_request` events read the workflow from the merge ref, this PR runs the new humble and jazzy jobs on itself.

## AI usage

**AI usage:** written with Claude Code during a review session on the header install PR listed above. The session found the CI gap and produced this fix.

**Self-review:** Simple PR, reviewed.

<details>
<summary><strong>Verification:</strong> the workflow parses as YAML locally, and the new humble and jazzy jobs ran green on this PR itself.</summary>

### Local YAML check

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build_test.yml'))"` printed `YAML OK`
- `actionlint` did not run. It is not installed on this machine.

### CI runs on this PR

The merge ref carries the new trigger, so the workflow ran on this PR after each of the three pushes.

- Latest run: `test_environment (humble)` passed in `1m38s`, `test_environment (jazzy)` passed in `1m34s`
- No colcon build ran locally for this change. It touches only the workflow file.

</details>
