### PR TITLE
ci: move the rolling job to the ubuntu resolute image

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -21,7 +21,7 @@ jobs:
             ros_distribution: kilted
             ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
-          - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
+          - docker_image: rostooling/setup-ros-docker:ubuntu-resolute-ros-rolling-ros-base-latest
             ros_distribution: rolling
             ros_version: 2
     container:


### PR DESCRIPTION
## Description

The `test_environment (rolling)` job fails on every PR to `main` since ROS Rolling dropped Ubuntu noble. The rolling `distribution.yaml` now lists resolute as the only Ubuntu release platform. On the old noble container, `rosdep` reports `No definition of [ament_cmake_auto] for OS version [noble]`, dependencies like `can_msgs` never install, and the build fails with `fatal error: can_msgs/msg/frame.hpp: No such file or directory`. A failing run:

- https://github.com/autowarefoundation/ros2_socketcan/actions/runs/32525818193/job/96907483794

This PR points the rolling matrix entry at `rostooling/setup-ros-docker:ubuntu-resolute-ros-rolling-ros-base-latest`, published on Docker Hub since 2026-07-15. The noble tag of the same image froze on 2025-08-16.

Note for the future: this breaks again at every Rolling platform hop. The focal, jammy and noble tags of the same image mark the earlier hops.

## AI usage

**AI usage:** written with Claude Code, which diagnosed the failure from the CI logs and the rosdistro platform list.

**Self-review:** Done, single line update.

<details>
<summary><strong>Verification:</strong> the workflow parses as YAML locally; the fix proves itself on this PR, because the rolling job runs here with the new image.</summary>

### Local YAML check

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build_test.yml'))"` printed `YAML OK`

### Docker Hub tag check

- `hub.docker.com` lists `ubuntu-resolute-ros-rolling-ros-base-latest`, last updated 2026-07-15
- The `ubuntu-noble-ros-rolling-ros-base-latest` tag froze on 2025-08-16

### What did not run here

- No local build in the resolute container ran; the CI run on this PR is the test.

</details>
