### PR TITLE
ci: add lyrical to the build matrix

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -14,11 +14,16 @@ jobs:
       matrix:
         ros_distribution:
           - kilted
+          - lyrical
           - rolling
         include:
           # Kilted Kaiju (May 2025 - December 2026)
           - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-kilted-ros-base-latest
             ros_distribution: kilted
+            ros_version: 2
+          # Lyrical Luth (May 2026 - May 2031)
+          - docker_image: rostooling/setup-ros-docker:ubuntu-resolute-ros-lyrical-ros-base-latest
+            ros_distribution: lyrical
             ros_version: 2
           # Rolling Ridley  (June 2020 - Present)
           - docker_image: rostooling/setup-ros-docker:ubuntu-resolute-ros-rolling-ros-base-latest


### PR DESCRIPTION
## Description

Lyrical Luth released on 2026-05-22, and `ros2_socketcan` is released into the lyrical rosdistro. This PR adds a lyrical job to the matrix, on the `rostooling/setup-ros-docker:ubuntu-resolute-ros-lyrical-ros-base-latest` image, published since 2026-07-15.

- #71

This PR is stacked on the rolling image fix and merges after it:

- #80

While the base is a feature branch, the workflow trigger does not match and no build runs here. When the PR above merges and its branch is deleted, GitHub retargets this PR to `main`, and the next push or reopen runs the full matrix, with the lyrical job in it.

## AI usage

**AI usage:** written with Claude Code on request, with the release dates and image tags checked against rosdistro, endoflife.date and Docker Hub.

**Self-review:** Simple change, done.

<details>
<summary><strong>Verification:</strong> the workflow parses as YAML locally; the lyrical job first runs after the retarget to `main`, and that run is the real test.</summary>

### Local YAML check

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build_test.yml'))"` printed `YAML OK`

### Fact checks

- `lyrical/distribution.yaml` in ros/rosdistro lists `ros2_socketcan` and `ros2_socketcan_msgs` with `release/lyrical/{package}/{version}` tags
- `hub.docker.com` lists `ubuntu-resolute-ros-lyrical-ros-base-latest`, last updated 2026-07-15
- endoflife.date: Lyrical Luth released 2026-05-22, EOL 2031-05-31; Kilted Kaiju EOL 2026-12-31

### What did not run here

- No CI runs on this PR while its base is a feature branch; the trigger only matches PRs to `develop` and `main`.
- No local build in the lyrical container ran; the first CI run after the retarget to `main` is the test.

</details>
