### PR TITLE
ci: add semantic pull request title check

### DIFF
--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -1,0 +1,12 @@
+name: semantic-pull-request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  semantic-pull-request:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/semantic-pull-request.yaml@v1


### PR DESCRIPTION
## Description

This PR adds the `semantic-pull-request` workflow from the autoware meta repository, without the sync-file-templates header, because this repository does not use file sync. The workflow calls the reusable title check in `autoware-github-actions@v1` and enforces conventional commit PR titles.

The workflow runs on `pull_request_target`, which reads the workflow file from the base branch. Each branch lineage therefore needs its own copy. The `jazzy` copy:

- #84

Dependabot PR titles pass the check without extra config. Dependabot detects the conventional commit history and prefixes its titles, as its PRs in the autoware meta repository show.

## AI usage

**AI usage:** written with Claude Code on request, copied from the autoware meta repository with the sync header removed.

**Self-review:** Done, simple pr. Same as https://github.com/autowarefoundation/autoware/blob/main/.github/workflows/semantic-pull-request.yaml

<details>
<summary><strong>Verification:</strong> the workflow parses as YAML locally; the check cannot run on its own PR, so the first PR after the merge is the real test.</summary>

### Local YAML check

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/semantic-pull-request.yaml'))"` printed `YAML OK`

### What did not run here

- The title check itself. `pull_request_target` reads the workflow from the base branch, so it first runs on the next PR opened or edited after this merges.
- The `test_environment (rolling)` job on this PR fails for the known unrelated reason until the rolling image fix merges: #80.

</details>
