### PR TITLE
test: cover node destruction after shutdown and while the context is up

### DIFF
--- a/.github/workflows/vcan_test.yml
+++ b/.github/workflows/vcan_test.yml
@@ -1,0 +1,37 @@
+name: vcan test
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  vcan_test:
+    runs-on: ubuntu-26.04
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-resolute-ros-lyrical-ros-base-latest
+      options: --cap-add NET_ADMIN
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          path: ros_ws/src
+
+      - name: create vcan0
+        run: |
+          apt-get update -qq
+          apt-get install -y -qq iproute2
+          ip link add dev vcan0 type vcan
+          ip link set up vcan0
+
+      - name: build and test
+        uses: ros-tooling/action-ros-ci@master
+        env:
+          ROS2_SOCKETCAN_REQUIRE_VCAN0: "1"
+        with:
+          package-name: ros2_socketcan ros2_socketcan_msgs
+          target-ros2-distro: lyrical
+          vcs-repo-file-url: ""

--- a/ros2_socketcan/CMakeLists.txt
+++ b/ros2_socketcan/CMakeLists.txt
@@ -97,6 +97,12 @@ if(BUILD_TESTING)
     test/sanity_checks.cpp)
   target_include_directories(${PROJECT_NAME}_test PUBLIC include)
   target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME})
+
+  ament_add_gtest(${PROJECT_NAME}_node_destruction_test
+    test/gtest_main.cpp
+    test/node_destruction.cpp)
+  target_compile_features(${PROJECT_NAME}_node_destruction_test PRIVATE cxx_std_17)
+  target_link_libraries(${PROJECT_NAME}_node_destruction_test socket_can_receiver_node)
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE

--- a/ros2_socketcan/src/socket_can_receiver_node.cpp
+++ b/ros2_socketcan/src/socket_can_receiver_node.cpp
@@ -21,9 +21,12 @@
 #include <agnocast_cie_thread_configurator/cie_thread_configurator.hpp>
 #endif
 
+#include <pthread.h>
+
 #include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -31,6 +34,15 @@ namespace lc = rclcpp_lifecycle;
 using LNI = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface;
 using lifecycle_msgs::msg::State;
 using namespace std::chrono_literals;
+
+namespace
+{
+// Sets the kernel name of a thread. The kernel keeps at most 15 characters.
+void set_thread_name(std::thread & thread, const std::string & name)
+{
+  pthread_setname_np(thread.native_handle(), name.substr(0, 15).c_str());
+}
+}  // namespace
 
 namespace drivers
 {
@@ -87,6 +99,7 @@ LNI::CallbackReturn SocketCanReceiverNode::on_configure(const lc::State & state)
 #else
   receiver_thread_ = std::make_unique<std::thread>(&SocketCanReceiverNode::receive, this);
 #endif
+  set_thread_name(*receiver_thread_, "rx:" + interface_);
 
   return LNI::CallbackReturn::SUCCESS;
 }

--- a/ros2_socketcan/test/node_destruction.cpp
+++ b/ros2_socketcan/test/node_destruction.cpp
@@ -1,0 +1,242 @@
+// Copyright 2026 the Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "lifecycle_msgs/msg/state.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "ros2_socketcan/socket_can_receiver.hpp"
+#include "ros2_socketcan/socket_can_receiver_node.hpp"
+
+using namespace std::chrono_literals;
+
+// The receiver thread must not outlive the node object, and a lifecycle
+// cleanup must end it while the node still exists. Each scenario runs in a
+// death test child, so that an abort or a hang in one scenario leaves the
+// other verdicts intact, and the parent still writes the gtest result file.
+
+namespace
+{
+constexpr auto kInterface = "vcan0";
+constexpr unsigned int kDeadlineSeconds = 10U;
+
+// The child prints this line right before it exits with 0. The parent
+// requires it, so that a child that never reaches the scenario cannot pass.
+constexpr auto kSuccessMessage = "node destroyed, receiver thread gone";
+
+// SocketCanReceiverNode::on_configure() names the receiver thread rx:<interface>.
+std::string receiver_thread_name()
+{
+  return std::string("rx:") + kInterface;
+}
+
+bool vcan0_available()
+{
+  try {
+    drivers::socketcan::SocketCanReceiver receiver{kInterface};
+    return true;
+  } catch (const std::exception &) {
+    return false;
+  }
+}
+
+int threads_named(const std::string & name)
+{
+  int count = 0;
+  for (const auto & task : std::filesystem::directory_iterator("/proc/self/task")) {
+    std::ifstream comm(task.path() / "comm");
+    std::string line;
+    std::getline(comm, line);
+    if (line == name) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+bool wait_for_thread_count(const std::string & name, int expected)
+{
+  const auto deadline = std::chrono::steady_clock::now() + 1s;
+  while (threads_named(name) != expected) {
+    if (std::chrono::steady_clock::now() > deadline) {
+      return false;
+    }
+    std::this_thread::sleep_for(10ms);
+  }
+  return true;
+}
+
+// Ends the child with a message and a non-zero exit code that the parent reports.
+void require(bool condition, const char * message, int exit_code)
+{
+  if (!condition) {
+    std::cerr << message << "\n";
+    std::exit(exit_code);
+  }
+}
+
+std::unique_ptr<drivers::socketcan::SocketCanReceiverNode> make_node(bool enable_can_fd)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({{"interface", kInterface}, {"enable_can_fd", enable_can_fd}});
+  return std::make_unique<drivers::socketcan::SocketCanReceiverNode>(std::move(options));
+}
+
+void configure_and_activate(drivers::socketcan::SocketCanReceiverNode & node)
+{
+  require(
+    node.configure().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
+    "configure failed", 2);
+  require(
+    node.activate().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+    "activate failed", 2);
+}
+
+void exit_after_success()
+{
+  if (rclcpp::ok()) {
+    rclcpp::shutdown();
+  }
+  std::cerr << kSuccessMessage << "\n";
+  std::exit(0);
+}
+
+// Destroys a configured and activated node, after rclcpp::shutdown() or with
+// the context up. Exit code 0 means that the destructor returned, the receiver
+// thread is gone, and the context is in the state the scenario expects.
+void destroy_node(bool shutdown_before_destruction, bool enable_can_fd)
+{
+  alarm(kDeadlineSeconds);
+  rclcpp::init(0, nullptr);
+
+  auto node = make_node(enable_can_fd);
+  configure_and_activate(*node);
+  require(wait_for_thread_count(receiver_thread_name(), 1), "receiver thread not found", 2);
+
+  if (shutdown_before_destruction) {
+    rclcpp::shutdown();
+  }
+  node.reset();
+
+  require(
+    wait_for_thread_count(receiver_thread_name(), 0),
+    "receiver thread still runs after node destruction", 3);
+  require(
+    shutdown_before_destruction || rclcpp::ok(),
+    "node destruction shut the context down", 4);
+  exit_after_success();
+}
+
+// Runs a cleanup transition, configures the node again, and then destroys it
+// with the context up. The receiver thread must end on cleanup and must run
+// again after the second configure.
+void cleanup_and_reconfigure_node()
+{
+  alarm(kDeadlineSeconds);
+  rclcpp::init(0, nullptr);
+
+  auto node = make_node(false);
+  configure_and_activate(*node);
+  require(wait_for_thread_count(receiver_thread_name(), 1), "receiver thread not found", 2);
+
+  require(
+    node->deactivate().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
+    "deactivate failed", 2);
+  require(
+    node->cleanup().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
+    "cleanup failed", 2);
+  require(
+    wait_for_thread_count(receiver_thread_name(), 0),
+    "receiver thread still runs after cleanup", 3);
+
+  configure_and_activate(*node);
+  require(
+    wait_for_thread_count(receiver_thread_name(), 1),
+    "receiver thread not found after the second configure", 5);
+  std::this_thread::sleep_for(200ms);
+  require(
+    threads_named(receiver_thread_name()) == 1,
+    "receiver thread ended after the second configure", 5);
+
+  node.reset();
+  require(
+    wait_for_thread_count(receiver_thread_name(), 0),
+    "receiver thread still runs after node destruction", 3);
+  require(rclcpp::ok(), "node destruction shut the context down", 4);
+  exit_after_success();
+}
+
+class SocketCanReceiverNodeDestruction : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    if (!vcan0_available()) {
+      if (std::getenv("ROS2_SOCKETCAN_REQUIRE_VCAN0") != nullptr) {
+        FAIL() << "vcan0 is required by ROS2_SOCKETCAN_REQUIRE_VCAN0 but not available";
+      }
+      GTEST_SKIP() << "vcan0 is not available";
+    }
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+  }
+};
+}  // namespace
+
+// On plain shutdown, for example SIGINT, the context goes down first. Then the
+// node goes out of scope without a lifecycle transition. The destructor of a
+// joinable std::thread calls std::terminate(), so this destruction must join
+// the thread.
+TEST_F(SocketCanReceiverNodeDestruction, completes_after_shutdown)
+{
+  EXPECT_EXIT(destroy_node(true, false), ::testing::ExitedWithCode(0), kSuccessMessage);
+}
+
+TEST_F(SocketCanReceiverNodeDestruction, completes_after_shutdown_with_can_fd)
+{
+  EXPECT_EXIT(destroy_node(true, true), ::testing::ExitedWithCode(0), kSuccessMessage);
+}
+
+// On a component unload, the context is still up and the node is destroyed
+// from the ACTIVE state without a transition. A join with no stop signal then
+// blocks forever, so destruction must stop the thread and must leave the
+// context up. A destructor that detaches the thread instead leaves it to run
+// on the destroyed node, and the child crashes on that use.
+TEST_F(SocketCanReceiverNodeDestruction, completes_while_context_is_up)
+{
+  EXPECT_EXIT(destroy_node(false, false), ::testing::ExitedWithCode(0), kSuccessMessage);
+}
+
+TEST_F(SocketCanReceiverNodeDestruction, completes_while_context_is_up_with_can_fd)
+{
+  EXPECT_EXIT(destroy_node(false, true), ::testing::ExitedWithCode(0), kSuccessMessage);
+}
+
+// A cleanup transition runs on_cleanup() while the context is up, so it needs
+// the same stop signal. A second configure must start a new thread, so the
+// stop signal must not stay set.
+TEST_F(SocketCanReceiverNodeDestruction, completes_after_cleanup_and_reconfigure)
+{
+  EXPECT_EXIT(cleanup_and_reconfigure_node(), ::testing::ExitedWithCode(0), kSuccessMessage);
+}


### PR DESCRIPTION
## Description

Regression tests for the crash on shutdown, and a CI job that runs them with a real `vcan0`:

- #48

`ros2_socketcan_node_destruction_test` holds five gtest death tests. Each one runs in a child process that configures and activates the receiver node on `vcan0`, checks that the receiver thread runs, and then requires that the thread is gone. An abort, a 10 s alarm, a leaked thread, or a context that went down is a failure. The child prints a fixed line before it exits with 0, and the parent requires that line, so a child that skips or returns early cannot pass. Without `vcan0` the tests skip. With `ROS2_SOCKETCAN_REQUIRE_VCAN0` set they fail instead.

1. **After shutdown**, classic and CAN FD. Destroy the node after `rclcpp::shutdown()`, the SIGINT order. On `main` the joinable `std::thread` calls `std::terminate()`, the crash from the issue. The destructor in the PR below fixes this pair.
2. **While the context is up**, classic and CAN FD. Destroy the node while the context is up, the order of a component unload. On `main` this aborts too. With the destructor alone, the join never returns, because the receive loop only exits on `rclcpp::ok()`. The test also requires that the context is still up afterwards, so a destructor cannot pass by shutting the context down. The FD variant exists because `receive()` has one loop per frame type.
3. **Cleanup and reconfigure.** Run `deactivate()` and `cleanup()`, which joins the thread in `on_cleanup()` with the context up, then configure and activate again, then destroy. On `main` and with the destructor alone, `cleanup()` blocks until the alarm. This is the hang behind `ros2 lifecycle set ... cleanup`. The second configure must start a new thread, so a stop signal must not stay set.

- #75

A stop flag on top of the destructor turns all five green. The tests are the baseline for that fix.

`on_configure()` now names the receiver thread `rx:<interface>`, for example `rx:can0`, right after it creates it, through a small static helper around `pthread_setname_np` and `native_handle()`. The test then sees in `/proc/self/task` whether `rx:vcan0` is still alive. The parent sets the name, so it is in place before `configure()` returns. On the agnocast build the thread first registers with the thread configurator for up to 1 s, so a name set by the thread itself would appear after the test gave up. `rcpputils::set_thread_name` offers the same call, but only on Lyrical and Rolling, and this package also builds on Kilted and Jazzy.

The `vcan test` workflow runs the test suite of both packages in the Lyrical image with the `NET_ADMIN` capability and creates `vcan0`. The kernel loads the `vcan` module on its own when the link is created, so the container needs no module tree and no `modprobe`. The job runs on `ubuntu-26.04`, because the `ubuntu-24.04` runner image has no `vcan` module. The job is not a required check. It stays red on `main` until the destructor and the stop flag land.

## AI usage

**AI usage:** written with Claude Code during a review of the destructor PR listed above, and reshaped twice after adversarial reviews with Claude Code.

**Self-review:** After lengthy checks, I think it looks good and covers things well now.

<details>
<summary><strong>Verification:</strong> in the CI Lyrical image with a real `vcan0`, all five tests fail on `main`, the destructor alone passes the two after-shutdown tests and fails the other three by alarm, the stop flag passes all five in 100 of 100 idle and 50 of 50 under load, and five wrong fixes are each rejected by the check built for them. The same ladder holds on the Jazzy agnocast build.</summary>

### Three states, CI Lyrical image, `--cap-add NET_ADMIN` only, 3 runs each

The image is `rostooling/setup-ros-docker:ubuntu-resolute-ros-lyrical-ros-base-latest`, built with the `action-ros-ci` command (no `CMAKE_BUILD_TYPE`). `vcan0` was created from a container with no `/lib/modules` and no `modprobe`.

| state | after shutdown, classic and FD | context up, classic and FD | cleanup and reconfigure |
|---|---|---|---|
| this branch | `Terminated by signal 6` | `Terminated by signal 6` | `Terminated by signal 14` at 10 s |
| `add-destructor` + this branch | `OK (238 ms)` | `Terminated by signal 14` | `Terminated by signal 14` |
| `fix/receiver-thread-stop-flag` at local `02d84ea` + this branch | `OK (239 ms)` | `OK (239 ms)` | `OK (441 ms)` |

- Identical verdicts in all 3 runs per state.
- `--gtest_repeat=20` on the stop flag: 100 `OK`, worst case `444 ms`. Under 48 busy loops on 24 CPUs, `--gtest_repeat=10`: 50 `OK`, worst case `516 ms`.
- `--gtest_repeat=20` on this branch: 0 `OK`, 80 `signal 6`, 20 `signal 14`.
- `colcon test` with lint on both states: `copyright`, `cpplint`, `uncrustify`, `lint_cmake`, `xmllint` all `0 failures`. Result file `ros2_socketcan_node_destruction_test.gtest.xml`: `5 tests, 0 errors, 5 failures, 0 skipped` on this branch, `5 tests, 0 errors, 0 failures, 0 skipped` on the stop flag.
- The stop-flag branch is local and not pushed yet. The table names its commit so that the row can be repeated once it is.

### Five wrong fixes, same image

- Destructor that calls `rclcpp::shutdown()` before the join: both context-up tests `Exited with exit status 4`, `node destruction shut the context down`.
- Destructor with `detach()`: both context-up tests `Terminated by signal 6`, cleanup by alarm. The two after-shutdown tests pass, because the detached thread exits on its own once the context is down.
- Stop flag that `on_configure()` never resets: the first four pass, cleanup `Exited with exit status 5`, `receiver thread not found after the second configure`.
- Stop flag in the classic loop only: four pass, `completes_while_context_is_up_with_can_fd` `Terminated by signal 14`.
- Child that skips (probe that makes `vcan0_available()` return false in the death test child only): all five `died but not with expected error` in 15 ms. The same binary without the probe passes all five.

### `ROS2_SOCKETCAN_REQUIRE_VCAN0`, after `ip link del vcan0`

- Unset: `5 tests` `SKIPPED`, `vcan0 is not available`.
- Set: `5 tests` `FAILED`, `vcan0 is required by ROS2_SOCKETCAN_REQUIRE_VCAN0 but not available`.

### Jazzy with `ENABLE_AGNOCAST=1`, agnocast 2.3.5, no thread configurator running, 10 runs each

- This branch: 40 `Terminated by signal 6`, 10 `Terminated by signal 14`, no `receiver thread not found`. Each child logs `No listener for non_ros_thread_info`.
- Stop flag: 50 `OK`, 1217 ms to 2229 ms per test, the agnocast IPC retry of 1 s per configure.
- Not run: a thread configurator that listens.

### CI on this PR

- `vcan_test` on `5787805`, run 32589644311: the container was created with `--cap-add NET_ADMIN` and no module mount, `ip link add dev vcan0 type vcan` succeeded, `1 tests failed out of 10`, four death tests `Terminated by signal 6` and one `Terminated by signal 14`, result file `5 tests, 0 errors, 5 failures, 0 skipped`.
- `test_environment (kilted)`, `(lyrical)`, `(rolling)` pass. The tests skip there.
- Earlier job shapes on the fork did not survive: a plain runner has no `vcan` module on `ubuntu-24.04`, and `setup-ros` on `ubuntu-26.04` failed with `No 'rosidl_typesupport_c' found`.

### Not run

- Kilted and Rolling with a `vcan0`.

</details>
